### PR TITLE
Add optional version argument to GitSpoofax parse table config

### DIFF
--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -17,16 +17,16 @@ case class Config(warmupIterations: Int = 1, benchmarkIterations: Int = 1, batch
 
 case class Language(id: String, name: String, extension: String, parseTable: ParseTable, sources: Sources, antlrBenchmarks: Seq[ANTLRBenchmark] = Seq.empty) {
     def parseTableStream(implicit suite: Suite) = parseTable match {
-        case parseTable @ GitSpoofax(_, _, dynamic) if dynamic => parseTable.bin(this)
+        case parseTable @ GitSpoofax(_, _, _, dynamic) if dynamic => parseTable.bin(this)
         case _ => parseTable.term(this)
     }
     def parseTablePath(implicit suite: Suite) = parseTable match {
-        case parseTable @ GitSpoofax(_, _, dynamic) if dynamic => parseTable.binPath(this)
+        case parseTable @ GitSpoofax(_, _, _, dynamic) if dynamic => parseTable.binPath(this)
         case _ => parseTable.termPath(this)
     }
     def parseTableTermPath(implicit suite: Suite) = parseTable.termPath(this)
     def dynamicParseTableGeneration = parseTable match {
-        case GitSpoofax(_, _, dynamic) => dynamic
+        case GitSpoofax(_, _, _, dynamic) => dynamic
         case _ => false
     }
 
@@ -82,7 +82,7 @@ sealed trait ParseTable {
     def term(language: Language)(implicit suite: Suite) = new FileInputStream(termPath(language).toString)
     def termPath(language: Language)(implicit suite: Suite): Path
 }
-case class GitSpoofax(repo: String, subDir: String, dynamic: Boolean = false) extends ParseTable {
+case class GitSpoofax(repo: String, subDir: String, version: String = "master", dynamic: Boolean = false) extends ParseTable {
     def repoDir(language: Language)(implicit suite: Suite) = Suite.languagesDir / language.id
     def spoofaxProjectDir(language: Language)(implicit suite: Suite) = repoDir(language) / RelPath(subDir)
     

--- a/scripts/setupLanguages.sc
+++ b/scripts/setupLanguages.sc
@@ -10,13 +10,14 @@ suite.languages.foreach { language =>
     println(" " + language.name)
 
     language.parseTable match {
-        case gitSpoofax @ GitSpoofax(repo: String, _, _) =>
+        case gitSpoofax @ GitSpoofax(repo: String, _, version: String, _) =>
             rm!    gitSpoofax.repoDir(language)
             mkdir! gitSpoofax.repoDir(language)
     
             timed("clone " + language.id) {
                 println(s"  Cloning ${repo}...")
                 %%("git", "clone", repo, ".")(gitSpoofax.repoDir(language))
+                %%("git", "checkout", version)
             }
 
             val configPath = gitSpoofax.spoofaxProjectDir(language) / "metaborg.yaml"

--- a/scripts/setupLanguages.sc
+++ b/scripts/setupLanguages.sc
@@ -16,7 +16,7 @@ suite.languages.foreach { language =>
             mkdir! repoDir
     
             timed("clone " + language.id) {
-                println(s"  Cloning ${repo}...")
+                println(s"  Cloning ${repo} (version: ${version})...")
                 %%("git", "clone", repo, ".")(repoDir)
                 %%("git", "checkout", version)(repoDir)
             }

--- a/scripts/setupLanguages.sc
+++ b/scripts/setupLanguages.sc
@@ -11,13 +11,14 @@ suite.languages.foreach { language =>
 
     language.parseTable match {
         case gitSpoofax @ GitSpoofax(repo: String, _, version: String, _) =>
-            rm!    gitSpoofax.repoDir(language)
-            mkdir! gitSpoofax.repoDir(language)
+            val repoDir = gitSpoofax.repoDir(language)
+            rm! repoDir
+            mkdir! repoDir
     
             timed("clone " + language.id) {
                 println(s"  Cloning ${repo}...")
-                %%("git", "clone", repo, ".")(gitSpoofax.repoDir(language))
-                %%("git", "checkout", version)
+                %%("git", "clone", repo, ".")(repoDir)
+                %%("git", "checkout", version)(repoDir)
             }
 
             val configPath = gitSpoofax.spoofaxProjectDir(language) / "metaborg.yaml"

--- a/scripts/spoofax.sc
+++ b/scripts/spoofax.sc
@@ -50,7 +50,7 @@ def getJSGLR2(variant: IntegrationVariant, language: Language) = {
 
 def getJSGLR1ParseTable(language: Language): JSGLR1ParseTable = {
     language.parseTable match {
-        case parseTable @ GitSpoofax(_, _, dynamic) =>
+        case parseTable @ GitSpoofax(_, _, _, dynamic) =>
             val parseTableTerm = readParseTableTerm(parseTable.term(language))
             val persistedTable = parseTable.bin(language)
 


### PR DESCRIPTION
Default value of this argument is `master`.
Just add a `version: <branch/commit/tag>` in the `config.yml` at the parse table repository, and you're good to go :smile: 

Note that I didn't test this yet, @maxdekrieger can you test if this does what you need? :slightly_smiling_face: 