### PR TITLE
Memory and TreeSitter benchmarks (and some other fixes)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,11 +15,11 @@ RUN apt-get install -y software-properties-common openjdk-8-jdk wget curl git ma
 
 # Install Maven 3
 RUN cd bin &&\
-    wget http://apache.mirror.anlx.net/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz &&\
-    tar -zxf apache-maven-3.5.4-bin.tar.gz &&\
-    cp -R apache-maven-3.5.4 /usr/local &&\
-    ln -s /usr/local/apache-maven-3.5.4/bin/mvn /usr/bin/mvn &&\
-    ln -s /usr/local/apache-maven-3.5.4/bin/mvnDebug /usr/bin/mvnDebug
+    wget http://apache.mirror.anlx.net/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz &&\
+    tar -zxf apache-maven-3.6.3-bin.tar.gz &&\
+    cp -R apache-maven-3.6.3 /usr/local &&\
+    ln -s /usr/local/apache-maven-3.6.3/bin/mvn /usr/bin/mvn &&\
+    ln -s /usr/local/apache-maven-3.6.3/bin/mvnDebug /usr/bin/mvnDebug
 
 # Local Maven settings (http://metaborg.org/dev/maven/#local-settings-file)
 RUN mkdir /root/.m2

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -12,6 +12,7 @@ DEV?=false
 JSGLR_DIR=$(SPOOFAX_DIR)/jsglr
 MEASUREMENTS_JAR=$(JSGLR_DIR)/org.spoofax.jsglr2.measure/target/org.spoofax.jsglr2.measure-2.6.0-SNAPSHOT.jar
 BENCHMARKS_JAR=$(JSGLR_DIR)/org.spoofax.jsglr2.benchmark/target/org.spoofax.jsglr2.benchmark-2.6.0-SNAPSHOT.jar
+TREE_SITTER_JAR=$(DATA_DIR)/tools/java-tree-sitter/java-tree-sitter/target/java-tree-sitter-0.0.1-SNAPSHOT.jar
 MEMORY_BENCHMARKS_JAR=$(DATA_DIR)/tools/simple-allocation-instrumenter/target/java-allocation-instrumenter-HEAD-SNAPSHOT.jar
 
 # Environment variables passed to the Ammonite/Python/R scripts
@@ -67,12 +68,20 @@ cleanMeasurements:
 benchmarks: $(BENCHMARKS_JAR)
 	amm benchmarks.sc
 
-$(BENCHMARKS_JAR): $(JSGLR_DIR)/org.spoofax.jsglr2.benchmark/src
+$(BENCHMARKS_JAR): $(TREE_SITTER_JAR) $(JSGLR_DIR)/org.spoofax.jsglr2.benchmark/src
 	mvn -f $(JSGLR_DIR)/org.spoofax.jsglr2.benchmark -q install
+
+# Pull custom java-tree-sitter library from https://github.com/mpsijm/java-tree-sitter
+$(TREE_SITTER_JAR):
+	if [ ! -d $(DATA_DIR)/tools/java-tree-sitter/.git ]; then git clone --recurse-submodules https://github.com/mpsijm/java-tree-sitter $(DATA_DIR)/tools/java-tree-sitter; fi
+	cd $(DATA_DIR)/tools/java-tree-sitter && \
+		git pull && \
+		mvn -q -DskipTests=true -Dmaven.javadoc.skip=true install
 
 cleanBenchmarks:
 	-rm -r $(DATA_DIR)/benchmarks
 	-rm -r $(JSGLR_DIR)/org.spoofax.jsglr2.benchmarks/target
+	-rm -rf $(DATA_DIR)/tools/java-tree-sitter
 
 
 # Performs memory benchmarks

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -12,6 +12,7 @@ DEV?=false
 JSGLR_DIR=$(SPOOFAX_DIR)/jsglr
 MEASUREMENTS_JAR=$(JSGLR_DIR)/org.spoofax.jsglr2.measure/target/org.spoofax.jsglr2.measure-2.6.0-SNAPSHOT.jar
 BENCHMARKS_JAR=$(JSGLR_DIR)/org.spoofax.jsglr2.benchmark/target/org.spoofax.jsglr2.benchmark-2.6.0-SNAPSHOT.jar
+MEMORY_BENCHMARKS_JAR=$(DATA_DIR)/tools/simple-allocation-instrumenter/target/java-allocation-instrumenter-HEAD-SNAPSHOT.jar
 
 # Environment variables passed to the Ammonite/Python/R scripts
 export JSGLR2EVALUATION_DATA_DIR=$(DATA_DIR)
@@ -20,11 +21,11 @@ export JSGLR2EVALUATION_FIGURES_DIR=$(FIGURES_DIR)
 export JSGLR2EVALUATION_DEV=$(DEV)
 
 
-all: languages sources preProcessing measurements benchmarks postProcessing figures publish
+all: languages sources preProcessing measurements benchmarks memoryBenchmarks postProcessing figures publish
 
-repeat: cleanMeasurements cleanBenchmarks measurements benchmarks postProcessing figures publish
+repeat: cleanMeasurements cleanBenchmarks measurements benchmarks memoryBenchmarks postProcessing figures publish
 
-clean: cleanLanguages cleanSources cleanMeasurements cleanBenchmarks cleanPostProcessing cleanFigures cleanArchive
+clean: cleanLanguages cleanSources cleanMeasurements cleanBenchmarks cleanMemoryBenchmarks cleanPostProcessing cleanFigures cleanArchive
 
 cleanAll: clean all
 
@@ -66,17 +67,28 @@ cleanMeasurements:
 benchmarks: $(BENCHMARKS_JAR)
 	amm benchmarks.sc
 
-# TODO: change absolute path to pull-and-build of my fork at https://github.com/mpsijm/simple-allocation-instrumenter
-memoryBenchmarks:
-	JAVA_OPTS="-Xmx8G -Xms8G -javaagent:/home/maarten/git/thesis/simple-allocation-instrumenter/target/java-allocation-instrumenter-HEAD-SNAPSHOT.jar -Djdk.attach.allowAttachSelf=true" amm memoryBenchmarks.sc
-
 $(BENCHMARKS_JAR): $(JSGLR_DIR)/org.spoofax.jsglr2.benchmark/src
 	mvn -f $(JSGLR_DIR)/org.spoofax.jsglr2.benchmark -q install
 
 cleanBenchmarks:
 	-rm -r $(DATA_DIR)/benchmarks
-	-rm -r $(DATA_DIR)/memoryBenchmarks
 	-rm -r $(JSGLR_DIR)/org.spoofax.jsglr2.benchmarks/target
+
+
+# Performs memory benchmarks
+memoryBenchmarks: $(MEMORY_BENCHMARKS_JAR)
+	JAVA_OPTS="-Xmx8G -javaagent:$(MEMORY_BENCHMARKS_JAR) -Djdk.attach.allowAttachSelf=true" amm memoryBenchmarks.sc
+
+# Pull custom java-allocation-instrumenter library from fork at https://github.com/mpsijm/simple-allocation-instrumenter
+$(MEMORY_BENCHMARKS_JAR):
+	if [ ! -d $(DATA_DIR)/tools/simple-allocation-instrumenter/.git ]; then git clone https://github.com/mpsijm/simple-allocation-instrumenter $(DATA_DIR)/tools/simple-allocation-instrumenter; fi
+	cd $(DATA_DIR)/tools/simple-allocation-instrumenter && \
+		git pull && \
+		mvn -q -DskipTests=true -Dmaven.javadoc.skip=true install
+
+cleanMemoryBenchmarks:
+	-rm -r $(DATA_DIR)/memoryBenchmarks
+	-rm -rf $(DATA_DIR)/tools/simple-allocation-instrumenter
 
 
 # Post process results from measurements and benchmarks

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -66,11 +66,16 @@ cleanMeasurements:
 benchmarks: $(BENCHMARKS_JAR)
 	amm benchmarks.sc
 
+# TODO: change absolute path to pull-and-build of my fork at https://github.com/mpsijm/simple-allocation-instrumenter
+memoryBenchmarks:
+	JAVA_OPTS="-Xmx8G -Xms8G -javaagent:/home/maarten/git/thesis/simple-allocation-instrumenter/target/java-allocation-instrumenter-HEAD-SNAPSHOT.jar -Djdk.attach.allowAttachSelf=true" amm memoryBenchmarks.sc
+
 $(BENCHMARKS_JAR): $(JSGLR_DIR)/org.spoofax.jsglr2.benchmark/src
 	mvn -f $(JSGLR_DIR)/org.spoofax.jsglr2.benchmark -q install
 
 cleanBenchmarks:
 	-rm -r $(DATA_DIR)/benchmarks
+	-rm -r $(DATA_DIR)/memoryBenchmarks
 	-rm -r $(JSGLR_DIR)/org.spoofax.jsglr2.benchmarks/target
 
 

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -158,13 +158,20 @@ def batchContent =
         |${withNav(batchTabs)}""".stripMargin
 
 val incrementalTabs = suite.languages.filter(_.sources.incremental.nonEmpty).map { language =>
-    (language.id, language.name, withNav(language.sources.incremental.map { source => {
+    val sourcesTabs = withNav(language.sources.incremental.map { source => {
         val plots = Seq("report", "report-except-first", "report-time-vs-bytes", "report-time-vs-changes", "report-time-vs-changes-3D")
         // TODO add field source.name?
         (source.id, source.id, plots.map { plot =>
             s"""<p><img src="./figures/incremental/${language.id}/${source.id}-parse/$plot.svg" /></p>"""
         }.mkString("\n"))
-    }}))
+    }})
+    (language.id, language.name,
+        s"""|<div class="row">
+            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-full-garbage.svg" /></div>
+            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-cache-size.svg" /></div>
+            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-incremental.svg" /></div>
+            |</div>
+            |${sourcesTabs}""")
 }
 
 val tabs = Seq(

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -85,7 +85,11 @@ if (!dev) {
 mkdir! dir
 
 cp.over(pwd / "website-style.css", dir / "style.css")
-cp.over(suite.dir / "archive.tar.gz", dir / "archive.tar.gz")
+try {
+    cp.over(suite.dir / "archive.tar.gz", dir / "archive.tar.gz")
+} catch {
+    case e => if (!dev) throw e;  // Do not throw NoSuchFileException in dev mode
+}
 cp.over(figuresDir, dir / "figures")
 
 suite.languages.filter(_.sourcesBatchNonEmpty.nonEmpty).map { language =>

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -162,7 +162,7 @@ val incrementalTabs = suite.languages.filter(_.sources.incremental.nonEmpty).map
         val plots = Seq("report", "report-except-first", "report-time-vs-bytes", "report-time-vs-changes", "report-time-vs-changes-3D")
         // TODO add field source.name?
         (source.id, source.id, plots.map { plot =>
-            s"""<p><img src="./figures/incremental/${language.id}/${source.id}-parse/$plot.svg" /></p>"""
+            s"""<p><img src="./figures/incremental/${language.id}/${source.id}-parse+implode/$plot.svg" /></p>"""
         }.mkString("\n"))
     }})
     (language.id, language.name,

--- a/scripts/batchPlots.R
+++ b/scripts/batchPlots.R
@@ -25,6 +25,7 @@ batchBenchmarksPlot <- function(inputFile, outputFile, dimension, unit, getLows,
                           ylim=c(0, 1.01 * max(getHighs(data))),
                           col=colors[match(variants, allVariants)],
                           legend=variants,
+                          args.legend=list(x=if(subtitle=="with imploding") "topleft" else "topright"),
                           beside=TRUE)
     
     segments(barCenters, lows, barCenters, highs, lwd = 1)

--- a/scripts/common.R
+++ b/scripts/common.R
@@ -20,6 +20,9 @@ savePlot <- function(plot, filename) {
   invisible(dev.off())
 }
 
-colors      <- c("#8c510a",  "#d8b365",  "#f6e8c3",     "#f5f5f5",             "#c7eae5", "#5ab4ac", "#01665e") # Color per parser variant, colorblind safe: http://colorbrewer2.org/#type=diverging&scheme=BrBG&n=6
-allVariants <- c("standard", "recovery", "incremental", "recoveryIncremental", "jsglr1",  "antlr",   "antlr-optimized")
+# Color per parser variant, colorblind safe: http://colorbrewer2.org/#type=diverging&scheme=BrBG&n=9
+colors      <- c("#8c510a",  "#bf812d",  "#dfc27d",  "#f6e8c3",     "#f5f5f5",
+                 "#c7eae5", "#80cdc1", "#35978f",         "#01665e")
+allVariants <- c("standard", "elkhound", "recovery", "incremental", "recoveryIncremental",
+                 "jsglr1",  "antlr",   "antlr-optimized", "tree-sitter")
 symbols     <- c(0,2,5,3) # Symbol per language

--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -49,6 +49,7 @@ case class Language(id: String, name: String, extension: String, parseTable: Par
         CSV.parse(measurementsDir / "batch" / "parsetable.csv").rows.head
 
     def benchmarksDir(implicit suite: Suite) = suite.benchmarksDir / id
+    def memoryBenchmarksDir(implicit suite: Suite) = suite.memoryBenchmarksDir / id
 
     def sourceFilesBatch(source: Option[BatchSource] = None)(implicit suite: Suite) = ls.rec! (source match {
         case Some(source) => sourcesDir / "batch" / source.id
@@ -147,12 +148,13 @@ case object External extends Comparison {
 }
 
 case class Suite(configPath: Path, languages: Seq[Language], dir: Path, warmupIterations: Int, benchmarkIterations: Int, batchSamples: Int, shrinkBatchSources: Option[Int], spoofaxDir: Path, figuresDir: Path, dev: Boolean) {
-    def languagesDir    = dir / "languages"
-    def sourcesDir      = dir / "sources"
-    def measurementsDir = dir / "measurements"
-    def benchmarksDir   = dir / "benchmarks"
-    def resultsDir      = dir / "results"
-    def websiteDir      = dir / "website"
+    def languagesDir        = dir / "languages"
+    def sourcesDir          = dir / "sources"
+    def measurementsDir     = dir / "measurements"
+    def benchmarksDir       = dir / "benchmarks"
+    def memoryBenchmarksDir = dir / "memoryBenchmarks"
+    def resultsDir          = dir / "results"
+    def websiteDir          = dir / "website"
 
     def scopes = Seq(
         if (languages.exists(_.sources.batch.nonEmpty)) Some("batch") else None,
@@ -182,17 +184,18 @@ object Suite {
         Suite(configPath, config.languages, dir, config.warmupIterations, config.benchmarkIterations, config.batchSamples, config.shrinkBatchSources, spoofaxDir, figuresDir, dev)
     }
 
-    implicit def languagesDir    = suite.languagesDir
-    implicit def sourcesDir      = suite.sourcesDir
-    implicit def measurementsDir = suite.measurementsDir
-    implicit def benchmarksDir   = suite.benchmarksDir
-    implicit def resultsDir      = suite.resultsDir
-    implicit def figuresDir      = suite.figuresDir
-    implicit def websiteDir      = suite.websiteDir
-    implicit def dev             = suite.dev
-    
+    implicit def languagesDir        = suite.languagesDir
+    implicit def sourcesDir          = suite.sourcesDir
+    implicit def measurementsDir     = suite.measurementsDir
+    implicit def benchmarksDir       = suite.benchmarksDir
+    implicit def memoryBenchmarksDir = suite.memoryBenchmarksDir
+    implicit def resultsDir          = suite.resultsDir
+    implicit def figuresDir          = suite.figuresDir
+    implicit def websiteDir          = suite.websiteDir
+    implicit def dev                 = suite.dev
+
     implicit def inScope(scope: String) = suite.scopes.contains(scope)
-    
+
     implicit def parseTableMeasurementsPath = resultsDir / "measurements-parsetable.csv"
     implicit def parsingMeasurementsPath    = resultsDir / "measurements-parsing.csv"
 

--- a/scripts/config.yml
+++ b/scripts/config.yml
@@ -13,7 +13,7 @@ languages:
       batch:
         - id: apache-commons-lang
           repo: https://github.com/apache/commons-lang.git
-        - id: https://github.com/netty/netty
+        - id: netty
           repo: https://github.com/netty/netty.git
         - id: spring-boot
           repo: https://github.com/spring-projects/spring-boot.git

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -12,6 +12,8 @@ COLORS = {
     "Batch": "rs",
     "Incremental": "g^",
     "IncrementalNoCache": "bv",
+    "TreeSitterIncremental": "g2",
+    "TreeSitterIncrementalNoCache": "b1",
     "jsglr2-standard": "rs",
     "jsglr2-elkhound": "yo",
     "jsglr2-incremental": "bv",  # TODO fix color for incremental: with vs. without cache
@@ -33,7 +35,7 @@ def base_plot(plot_size, title, x_label, y_label, z_label="", subplot_kwargs=Non
 
     ax.margins(*(0.1 / x for x in plot_size))
 
-    ax.set_title(title, y=1.0 + 0.4 / float(plot_size[1]), va="bottom")
+    ax.set_title(title, y=1.0 + 0.6 / float(plot_size[1]), va="bottom")
     ax.set_xlabel(x_label)
     ax.set_ylabel(y_label)
     if z_label:
@@ -166,6 +168,20 @@ def plot_times_vs_changes_3d(rows):
     return fig
 
 
+def parser_types(include_batch=True, include_tree_sitter=False):
+    types = []
+    if include_batch:
+        types.append("Batch")
+    types.append("Incremental")
+    if include_batch:
+        types.append("IncrementalNoCache")
+    if include_tree_sitter:
+        types.append("TreeSitterIncremental")
+        if include_batch:
+            types.append("TreeSitterIncrementalNoCache")
+    return types
+
+
 def main():
     incremental_results_dir = path.join(DATA_DIR, "results", "incremental")
 
@@ -189,8 +205,8 @@ def main():
                 makedirs(figure_path, exist_ok=True)
 
                 figures = [
-                    (plot_times(result_data, ["Batch", "Incremental", "IncrementalNoCache"]), "report"),
-                    (plot_times(result_data_except_first, ["Incremental"]), "report-except-first"),
+                    (plot_times(result_data, parser_types(True, "implode" in csv_basename)), "report"),
+                    (plot_times(result_data_except_first, parser_types(False, "implode" in csv_basename)), "report-except-first"),
                     (plot_times_vs_changes(result_data_except_first, "bytes", "Added", "Removed"),
                      "report-time-vs-bytes"),
                     (plot_times_vs_changes(result_data_except_first, "chunks", "Changes"), "report-time-vs-changes"),

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -177,6 +177,10 @@ def main():
                 result_data[0]["Added"] = None
                 result_data_except_first = result_data[1:]
 
+                if len([x for x in result_data if x["Batch"] or x["Incremental"] or x["IncrementalNoCache"]]) <= 0:
+                    print("    No data found, skipping")
+                    continue
+
                 figure_path = path.join(FIGURES_DIR, "incremental", language.name, csv_basename)
                 makedirs(figure_path, exist_ok=True)
 

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -111,9 +111,13 @@ def plot_times(rows, parser_types):
     ax2.plot(x, y, "yo", label="Change size", markersize=3)  # clip_on=False won't work here due to custom z-order
 
     for column in parser_types:
-        x, y, y_err = zip(*((int(row["i"]), float(row[column]), float(row[column + " Error (99.9%)"] or 0))
-                            for row in rows if row[column]))
-        ax1.errorbar(x, y, y_err, fmt=COLORS[column], label=column, ecolor="k", elinewidth=1, capsize=2, barsabove=True, clip_on=False)
+        try:
+            x, y, y_err = zip(*((int(row["i"]), float(row[column]), float(row[column + " Error (99.9%)"] or 0))
+                                for row in rows if row[column]))
+            ax1.errorbar(x, y, y_err, fmt=COLORS[column], label=column.replace("TreeSitterIncremental", "TreeSitter"),
+                         ecolor="k", elinewidth=1, capsize=2, barsabove=True, clip_on=False)
+        except:
+            print("    Parser type " + column + " not found")
 
     # Combine legends for both axes (https://stackoverflow.com/a/10129461)
     lines1, labels1 = ax1.get_legend_handles_labels()

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -25,11 +25,13 @@ def read_csv(p):
         return [{h: v for h, v in zip(header, line)} for line in lines[1:]]
 
 
-def base_plot(plot_size, x_label, y_label, z_label="", subplot_kwargs=None):
+def base_plot(plot_size, title, x_label, y_label, z_label="", subplot_kwargs=None):
     fig = plt.figure(figsize=plot_size[:2])
     ax = fig.add_subplot(**(subplot_kwargs if subplot_kwargs is not None else {}))
 
     ax.margins(*(0.1 / x for x in plot_size))
+
+    ax.set_title(title, y=1.0 + 0.4 / float(plot_size[1]), va="bottom")
     ax.set_xlabel(x_label)
     ax.set_ylabel(y_label)
     if z_label:
@@ -46,7 +48,8 @@ def plot_memory_batch(rows, garbage):
     memoryErrorColumn = f"Error {garbage}."
 
     plot_size = (8, 6)
-    fig, ax = base_plot(plot_size, "File size (bytes)", "Memory (MiB)")
+    title = "Memory usage during parsing" if garbage == "incl" else "Memory increase of cache"
+    fig, ax = base_plot(plot_size, title, "File size (bytes)", "Memory (MiB)")
 
     parsers = list(set(row["Parser"] for row in rows))
     for parser in parsers:
@@ -62,7 +65,7 @@ def plot_memory_batch(rows, garbage):
 
 def plot_memory_incremental(rows):
     plot_size = (8, 6)
-    fig, ax = base_plot(plot_size, "Change size (bytes)", "Memory (MiB)")
+    fig, ax = base_plot(plot_size, "Memory usage", "Change size (bytes)", "Memory (MiB)")
 
     parsers = list(set(row["Parser"] for row in rows if "incremental" in row["Parser"]))
 
@@ -85,7 +88,7 @@ def plot_memory_incremental(rows):
 def plot_times(rows, parser_types):
     n = len(rows)
     plot_size = (8 if n < 50 else 12 if n < 100 else 18 if n < 200 else 24, 6)
-    fig, ax1 = base_plot(plot_size, "Version number", "Parse time (ms)")
+    fig, ax1 = base_plot(plot_size, "Parse time and change size per version", "Version number", "Parse time (ms)")
 
     # Plot lines on ax2 below those on ax1 (https://stackoverflow.com/a/57307539)
     ax1.set_zorder(1)  # default z order is 0 for ax1 and ax2
@@ -114,7 +117,7 @@ def plot_times(rows, parser_types):
 
 
 def plot_times_vs_changes(rows, unit, *changes):
-    fig, ax = base_plot((8, 6), f"Change size ({unit})", "Parse time (ms)")
+    fig, ax = base_plot((8, 6), "Parse time vs. change size", f"Change size ({unit})", "Parse time (ms)")
 
     x, y = zip(*((sum(int(row[change]) for change in changes), float(row["Incremental"]))
                  for row in rows if row["Incremental"]))
@@ -125,7 +128,7 @@ def plot_times_vs_changes(rows, unit, *changes):
 
 
 def plot_times_vs_changes_3d(rows):
-    fig, ax = base_plot((6, 6, 6), "Change size (bytes)", "Change size (chunks)", "Parse time (ms)",
+    fig, ax = base_plot((6, 6, 6), "Parse time vs. change size", "Change size (bytes)", "Change size (chunks)", "Parse time (ms)",
                         {"projection": "3d"})
 
     x, y, z = zip(*((int(row["Added"]) + int(row["Removed"]), int(row["Changes"]), float(row["Incremental"]))

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -49,7 +49,7 @@ def plot_memory_batch(rows, garbage):
     memoryErrorColumn = f"Error {garbage}."
 
     plot_size = (8, 6)
-    title = "Memory usage during parsing" if garbage == "incl" else "Memory increase of cache"
+    title = "Memory usage during parsing in batch mode" if garbage == "incl" else "Memory increase of cache after first parse"
     fig, ax = base_plot(plot_size, title, "File size (bytes)", "Memory (MiB)")
 
     parsers = list(set(row["Parser"] for row in rows))
@@ -69,7 +69,7 @@ def plot_memory_batch(rows, garbage):
 
 def plot_memory_incremental(rows):
     plot_size = (8, 6)
-    fig, ax = base_plot(plot_size, "Memory usage", "Change size (bytes)", "Memory (MiB)")
+    fig, ax = base_plot(plot_size, "Memory usage in incremental mode", "Change size (bytes)", "Memory (MiB)")
 
     parsers = list(set(row["Parser"] for row in rows if "incremental" in row["Parser"]))
     for parser in parsers:
@@ -107,7 +107,7 @@ def plot_times(rows, parser_types):
     ax2.tick_params(labelcolor="y")
 
     x, y = zip(*((int(row["i"]), int(row["Removed"]) + int(row["Added"])) for row in rows if row["Added"]))
-    ax2.plot(x, y, "yo", label="Change size", markersize=3)
+    ax2.plot(x, y, "yo", label="Change size", markersize=3)  # clip_on=False won't work here due to custom z-order
 
     for column in parser_types:
         x, y, y_err = zip(*((int(row["i"]), float(row[column]), float(row[column + " Error (99.9%)"] or 0))
@@ -119,7 +119,8 @@ def plot_times(rows, parser_types):
     lines2, labels2 = ax2.get_legend_handles_labels()
     ax2.legend(lines1 + lines2, labels1 + labels2, loc="lower center", bbox_to_anchor=(0.5, 1.0), ncol=4)
 
-    ax1.set_xlim(-0.2)
+    max_i = max(float(row["i"]) for row in rows)
+    ax1.set_xlim(-max_i / 50, max_i + max_i / 50)
     ax1.set_ylim(0)
     ax2.set_ylim(0)
 

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -56,7 +56,10 @@ def plot_memory_batch(rows, garbage):
     for parser in parsers:
         x, y, y_err = zip(*((int(row["Size"]), float(row[memoryColumn]) / MiB, float(row[memoryErrorColumn] or 0) / MiB)
                             for row in rows if row["Parser"] == parser and row[memoryColumn]))
-        ax.errorbar(x, y, y_err, fmt=COLORS[parser], label=parser, ecolor="k", elinewidth=1, capsize=2, barsabove=True)
+        ax.errorbar(x, y, y_err, fmt=COLORS[parser], label=parser, ecolor="k", elinewidth=1, capsize=2, barsabove=True, clip_on=False)
+
+    ax.set_xlim(0)
+    ax.set_ylim(0)
 
     ax.legend(*ax.get_legend_handles_labels(), loc="lower center", bbox_to_anchor=(0.5, 1.0), ncol=4)
 
@@ -69,16 +72,19 @@ def plot_memory_incremental(rows):
     fig, ax = base_plot(plot_size, "Memory usage", "Change size (bytes)", "Memory (MiB)")
 
     parsers = list(set(row["Parser"] for row in rows if "incremental" in row["Parser"]))
-
     for parser in parsers:
         for garbage in ["incl", "excl"]:
             color = "bv" if garbage == "incl" else "b^"
+            label = "During parsing" if garbage == "incl" else "Cache increase"
             memoryColumn = f"Memory ({garbage}. garbage)"
             memoryErrorColumn = f"Error {garbage}."
 
             x, y, y_err = zip(*((int(row["Added"]) + int(row["Removed"]), float(row[memoryColumn]) / MiB, float(row[memoryErrorColumn] or 0) / MiB)
                                 for row in rows if row["Parser"] == parser and row[memoryColumn]))
-            ax.errorbar(x, y, y_err, fmt=color, label=memoryColumn, ecolor="k", elinewidth=1, capsize=2, barsabove=True)
+            ax.errorbar(x, y, y_err, fmt=color, label=label, ecolor="k", elinewidth=1, capsize=2, barsabove=True, clip_on=False)
+
+    ax.set_xlim(0)
+    ax.set_ylim(0)
 
     ax.legend(*ax.get_legend_handles_labels(), loc="lower center", bbox_to_anchor=(0.5, 1.0), ncol=4)
 
@@ -106,12 +112,16 @@ def plot_times(rows, parser_types):
     for column in parser_types:
         x, y, y_err = zip(*((int(row["i"]), float(row[column]), float(row[column + " Error (99.9%)"] or 0))
                             for row in rows if row[column]))
-        ax1.errorbar(x, y, y_err, fmt=COLORS[column], label=column, ecolor="k", elinewidth=1, capsize=2, barsabove=True)
+        ax1.errorbar(x, y, y_err, fmt=COLORS[column], label=column, ecolor="k", elinewidth=1, capsize=2, barsabove=True, clip_on=False)
 
     # Combine legends for both axes (https://stackoverflow.com/a/10129461)
     lines1, labels1 = ax1.get_legend_handles_labels()
     lines2, labels2 = ax2.get_legend_handles_labels()
     ax2.legend(lines1 + lines2, labels1 + labels2, loc="lower center", bbox_to_anchor=(0.5, 1.0), ncol=4)
+
+    ax1.set_xlim(-0.2)
+    ax1.set_ylim(0)
+    ax2.set_ylim(0)
 
     fig.tight_layout()
     return fig
@@ -122,7 +132,10 @@ def plot_times_vs_changes(rows, unit, *changes):
 
     x, y = zip(*((sum(int(row[change]) for change in changes), float(row["Incremental"]))
                  for row in rows if row["Incremental"]))
-    ax.plot(x, y, COLORS["Incremental"], label="Incremental", markersize=3)
+    ax.plot(x, y, COLORS["Incremental"], label="Incremental", markersize=3, clip_on=False)
+
+    ax.set_xlim(0)
+    ax.set_ylim(0)
 
     fig.tight_layout()
     return fig

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -2,6 +2,7 @@ import csv
 from os import makedirs, path, scandir, remove, environ
 
 import matplotlib.pyplot as plt
+import mpl_toolkits.mplot3d.art3d as art3d
 import pdftools
 
 DATA_DIR = environ["JSGLR2EVALUATION_DATA_DIR"]
@@ -133,7 +134,14 @@ def plot_times_vs_changes_3d(rows):
 
     x, y, z = zip(*((int(row["Added"]) + int(row["Removed"]), int(row["Changes"]), float(row["Incremental"]))
                     for row in rows if row["Incremental"]))
-    ax.plot(x, y, z, COLORS["Incremental"], label="Incremental", markersize=3)
+    # ax.plot(x, y, z, COLORS["Incremental"], label="Incremental", markersize=3)
+    for xi, yi, zi in zip(x, y, z):
+        ax.add_line(art3d.Line3D(*zip((xi, yi, 0), (xi, yi, zi)), color='g', marker='o', markersize=3, markevery=(1, 1)))
+
+    # We need to manually set the upper limit here, because we don't call a proper plot function but manually draw lines
+    ax.set_xlim3d(0, max(1, *x))
+    ax.set_ylim3d(0, max(1, *y))
+    ax.set_zlim3d(0, max(1, *z))
 
     ax.view_init(elev=30, azim=-45)
     return fig

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -13,6 +13,7 @@ COLORS = {
     "Incremental": "g^",
     "IncrementalNoCache": "bv",
     "jsglr2-standard": "rs",
+    "jsglr2-elkhound": "yo",
     "jsglr2-incremental": "bv",  # TODO fix color for incremental: with vs. without cache
 }
 

--- a/scripts/memoryBenchmarks.sc
+++ b/scripts/memoryBenchmarks.sc
@@ -61,7 +61,7 @@ suite.languages.foreach { language =>
     val sampledFilesBatch = scala.util.Random.shuffle(language.sourceFilesBatch() ++ language.sourceFilesIncremental).take(numSamples)
     val sampledFilesIncremental = scala.util.Random.shuffle(incrementalSources).take(numSamples)
 
-    parsers.foreach { parser =>
+    parsers.filter(_.isInstanceOf[JSGLR2Parser]).foreach { parser =>
         timed("memoryBenchmarks " + language.id + " " + parser.id) {
             val jsglr2parser = parser.asInstanceOf[JSGLR2Parser]
 

--- a/scripts/memoryBenchmarks.sc
+++ b/scripts/memoryBenchmarks.sc
@@ -19,11 +19,6 @@ import scala.collection.JavaConverters._
 
 val diff: IStringDiff = new JGitHistogramDiff();
 
-val gc = () => {
-    java.lang.System.gc()
-    // com.google.common.testing.GcFinalization.awaitFullGc()
-}
-
 val allocationSizeMeasurer = new AllocationSizeMeasurer();
 
 println("Executing memory benchmarks...")
@@ -75,7 +70,7 @@ suite.languages.foreach { language =>
                 val filename = file relativeTo language.sourcesDir
 
                 val results: (Seq[Long], Seq[Long]) = (1 to (warmupIterations + benchmarkIterations)).map { i =>
-                    gc()
+                    java.lang.System.gc()
 
                     val parserSizeBefore = GraphLayout.parseInstance(jsglr2parser.jsglr2).totalSize()
                     allocationSizeMeasurer.startMeasure()
@@ -112,7 +107,7 @@ suite.languages.foreach { language =>
                 val filename = file2 relativeTo language.sourcesDir
 
                 val results: (Seq[Long], Seq[Long]) = (1 to (warmupIterations + benchmarkIterations)).map { i =>
-                    gc()
+                    java.lang.System.gc()
 
                     jsglr2parser.jsglr2.parseResult(input1, "some random name to trigger caching", null)
 

--- a/scripts/memoryBenchmarks.sc
+++ b/scripts/memoryBenchmarks.sc
@@ -43,21 +43,38 @@ suite.languages.foreach { language =>
     write.over(resultCsvBatch,       """"Parser","File","Size","Memory (incl. garbage)","Error incl.","Memory (excl. garbage)","Error excl."""" + "\n")
     write.over(resultCsvIncremental, """"Parser","File","Previous","Size","Added","Removed","Changes","Memory (incl. garbage)","Error incl.","Memory (excl. garbage)","Error excl."""" + "\n")
 
-    // (if (language.name == "Java") List() else parsers).foreach { parser =>
+    val incrementalSources = language.sources.incremental.flatMap { source =>
+        val sourceDir = language.sourcesDir / "incremental" / source.id
+        val versions = (ls! sourceDir).map(path => (path relativeTo sourceDir).toString.toInt).sorted
+        versions.flatMap { version =>
+            val versionDir = sourceDir / version.toString
+            (ls! versionDir).map { file =>
+                val previousFile = sourceDir / (version - 1).toString / (file relativeTo versionDir)
+                (previousFile, file)
+            }.filter(exists! _._1).map { case (file1, file2) =>
+                val diffList: java.util.List[EditorUpdate] = diff.diff(read! file1, read! file2)
+                val deleted = diffList.asScala.map(_.deletedLength).sum
+                val inserted = diffList.asScala.map(_.insertedLength).sum
+                val numChanges = diffList.size
+
+                (file1, file2, deleted, inserted, numChanges)
+            }.filter(_._5 > 0)
+        }
+    }
+
+    val numSamples = 100 // TODO this could be configurable
+    val sampledFilesBatch = scala.util.Random.shuffle(language.sourceFilesBatch() ++ language.sourceFilesIncremental).take(numSamples)
+    val sampledFilesIncremental = scala.util.Random.shuffle(incrementalSources).take(numSamples)
+
     parsers.foreach { parser =>
         timed("memoryBenchmarks " + language.id + " " + parser.id) {
             val jsglr2parser = parser.asInstanceOf[JSGLR2Parser]
 
-            // TODO update the shuffling
-            // scala.util.Random.setSeed(42)
-            // scala.util.Random.shuffle(language.sourceFilesBatch() ++ language.sourceFilesIncremental).take(/*4*/2).foreach { file =>
-            scala.util.Random.shuffle(language.sourceFilesBatch() ++ language.sourceFilesIncremental).take(42).foreach { file =>
+            sampledFilesBatch.foreach { file =>
                 val input = read! file
                 val filename = file relativeTo language.sourcesDir
-                // println(filename)
 
                 val results: (Seq[Long], Seq[Long]) = (1 to (warmupIterations + benchmarkIterations)).map { i =>
-                    // println(i)
                     gc()
 
                     val parserSizeBefore = GraphLayout.parseInstance(jsglr2parser.jsglr2).totalSize()
@@ -67,11 +84,6 @@ suite.languages.foreach { language =>
 
                     val memoryIncl = allocationSizeMeasurer.endMeasure()
                     val parserSizeAfter = GraphLayout.parseInstance(jsglr2parser.jsglr2).totalSize()
-
-                    // println("Garbage: " + memoryIncl)
-                    // println("Before:  " + parserSizeBefore)
-                    // println("After:   " + parserSizeAfter)
-                    // println("Cache:   " + (parserSizeAfter - parserSizeBefore))
 
                     jsglr2parser.jsglr2 match {
                         case j: org.spoofax.jsglr2.JSGLR2ImplementationWithCache[_, _, _, _, _, _] => j.clearCache()
@@ -94,36 +106,12 @@ suite.languages.foreach { language =>
                 }
             }
 
-            val incrementalSources = language.sources.incremental.flatMap { source =>
-                val sourceDir = language.sourcesDir / "incremental" / source.id
-                val versions = (ls! sourceDir).map(path => (path relativeTo sourceDir).toString.toInt).sorted
-                versions.flatMap { version =>
-                    val versionDir = sourceDir / version.toString
-                    (ls! versionDir).map { file =>
-                        val previousFile = sourceDir / (version - 1).toString / (file relativeTo versionDir)
-                        (previousFile, file)
-                    }.filter(exists! _._1).map { case (file1, file2) => 
-                        val diffList: java.util.List[EditorUpdate] = diff.diff(read! file1, read! file2)
-                        val deleted = diffList.asScala.map(_.deletedLength).sum
-                        val inserted = diffList.asScala.map(_.insertedLength).sum
-                        val numChanges = diffList.size
-
-                        (file1, file2, deleted, inserted, numChanges)
-                    }.filter(_._5 > 0)
-                }
-            }
-
-            // TODO update the shuffling
-            // scala.util.Random.setSeed(42)
-            // scala.util.Random.shuffle(incrementalSources).take(/*4*/2).foreach { case (file1, file2, deleted, inserted, numChanges) =>
-            scala.util.Random.shuffle(incrementalSources).take(42).foreach { case (file1, file2, deleted, inserted, numChanges) =>
+            sampledFilesIncremental.foreach { case (file1, file2, deleted, inserted, numChanges) =>
                 val input1 = read! file1
                 val input2 = read! file2
                 val filename = file2 relativeTo language.sourcesDir
-                // println(filename)
 
                 val results: (Seq[Long], Seq[Long]) = (1 to (warmupIterations + benchmarkIterations)).map { i =>
-                    // println(i)
                     gc()
 
                     jsglr2parser.jsglr2.parseResult(input1, "some random name to trigger caching", null)
@@ -135,11 +123,6 @@ suite.languages.foreach { language =>
 
                     val memoryIncl = allocationSizeMeasurer.endMeasure()
                     val parserSizeAfter = GraphLayout.parseInstance(jsglr2parser.jsglr2).totalSize()
-
-                    // println("Garbage: " + memoryIncl)
-                    // println("Before:  " + parserSizeBefore)
-                    // println("After:   " + parserSizeAfter)
-                    // println("Cache:   " + (parserSizeAfter - parserSizeBefore))
 
                     jsglr2parser.jsglr2 match {
                         case j: org.spoofax.jsglr2.JSGLR2ImplementationWithCache[_, _, _, _, _, _] => j.clearCache()

--- a/scripts/memoryBenchmarks.sc
+++ b/scripts/memoryBenchmarks.sc
@@ -1,0 +1,166 @@
+import $ivy.`com.lihaoyi::ammonite-ops:2.2.0`, ammonite.ops._
+import $file.spoofaxDeps
+import $ivy.`com.google.guava:guava-testlib:30.0-jre`
+import $ivy.`com.google.code.java-allocation-instrumenter:java-allocation-instrumenter:HEAD-SNAPSHOT`
+import $ivy.`org.openjdk.jol:jol-core:0.14`
+
+import $file.common, common._, Suite._
+import $file.spoofax, spoofax._
+import $file.parsers, parsers._
+
+import java.lang.management.ManagementFactory
+import com.google.monitoring.runtime.instrumentation.AllocationSizeMeasurer
+import org.openjdk.jol.info.GraphLayout
+
+import org.spoofax.jsglr2.incremental.EditorUpdate
+import org.spoofax.jsglr2.incremental.diff.{IStringDiff,JGitHistogramDiff}
+
+import scala.collection.JavaConverters._
+
+val diff: IStringDiff = new JGitHistogramDiff();
+
+val gc = () => {
+    java.lang.System.gc()
+    // com.google.common.testing.GcFinalization.awaitFullGc()
+}
+
+val allocationSizeMeasurer = new AllocationSizeMeasurer();
+
+println("Executing memory benchmarks...")
+
+suite.languages.foreach { language =>
+    println(" " + language.name)
+
+    val parsers = Parser.variants(language)
+
+    val warmupIterations = suite.warmupIterations
+    val benchmarkIterations = suite.benchmarkIterations
+
+    mkdir! language.memoryBenchmarksDir
+    val resultCsvBatch = language.memoryBenchmarksDir / "batch.csv"
+    val resultCsvIncremental = language.memoryBenchmarksDir / "incremental.csv"
+
+    write.over(resultCsvBatch,       """"Parser","File","Size","Memory (incl. garbage)","Error incl.","Memory (excl. garbage)","Error excl."""" + "\n")
+    write.over(resultCsvIncremental, """"Parser","File","Previous","Size","Added","Removed","Changes","Memory (incl. garbage)","Error incl.","Memory (excl. garbage)","Error excl."""" + "\n")
+
+    // (if (language.name == "Java") List() else parsers).foreach { parser =>
+    parsers.foreach { parser =>
+        timed("memoryBenchmarks " + language.id + " " + parser.id) {
+            val jsglr2parser = parser.asInstanceOf[JSGLR2Parser]
+
+            // TODO update the shuffling
+            // scala.util.Random.setSeed(42)
+            // scala.util.Random.shuffle(language.sourceFilesBatch() ++ language.sourceFilesIncremental).take(/*4*/2).foreach { file =>
+            scala.util.Random.shuffle(language.sourceFilesBatch() ++ language.sourceFilesIncremental).take(42).foreach { file =>
+                val input = read! file
+                val filename = file relativeTo language.sourcesDir
+                // println(filename)
+
+                val results: (Seq[Long], Seq[Long]) = (1 to (warmupIterations + benchmarkIterations)).map { i =>
+                    // println(i)
+                    gc()
+
+                    val parserSizeBefore = GraphLayout.parseInstance(jsglr2parser.jsglr2).totalSize()
+                    allocationSizeMeasurer.startMeasure()
+
+                    jsglr2parser.jsglr2.parseResult(input, "some random name to trigger caching", null)
+
+                    val memoryIncl = allocationSizeMeasurer.endMeasure()
+                    val parserSizeAfter = GraphLayout.parseInstance(jsglr2parser.jsglr2).totalSize()
+
+                    // println("Garbage: " + memoryIncl)
+                    // println("Before:  " + parserSizeBefore)
+                    // println("After:   " + parserSizeAfter)
+                    // println("Cache:   " + (parserSizeAfter - parserSizeBefore))
+
+                    jsglr2parser.jsglr2 match {
+                        case j: org.spoofax.jsglr2.JSGLR2ImplementationWithCache[_, _, _, _, _, _] => j.clearCache()
+                        case _ => ()
+                    }
+
+                    Some((memoryIncl, parserSizeAfter - parserSizeBefore))
+                }.drop(warmupIterations).flatten.unzip
+
+                write.append(resultCsvBatch, s""""${parser.id}","${filename}",${file.size},""")
+                if (results._1.length == 0) {
+                    write.append(resultCsvBatch, ",,,\n")
+                } else {
+                    val memoryIncl = results._1.sum / results._1.length
+                    val memoryExcl = results._2.sum / results._2.length
+                    val memoryInclError = results._1.map(v => (v - memoryIncl).abs).max
+                    val memoryExclError = results._2.map(v => (v - memoryExcl).abs).max
+
+                    write.append(resultCsvBatch, s"""${memoryIncl},${memoryInclError},${memoryExcl},${memoryExclError}""" + "\n")
+                }
+            }
+
+            val incrementalSources = language.sources.incremental.flatMap { source =>
+                val sourceDir = language.sourcesDir / "incremental" / source.id
+                val versions = (ls! sourceDir).map(path => (path relativeTo sourceDir).toString.toInt).sorted
+                versions.flatMap { version =>
+                    val versionDir = sourceDir / version.toString
+                    (ls! versionDir).map { file =>
+                        val previousFile = sourceDir / (version - 1).toString / (file relativeTo versionDir)
+                        (previousFile, file)
+                    }.filter(exists! _._1).map { case (file1, file2) => 
+                        val diffList: java.util.List[EditorUpdate] = diff.diff(read! file1, read! file2)
+                        val deleted = diffList.asScala.map(_.deletedLength).sum
+                        val inserted = diffList.asScala.map(_.insertedLength).sum
+                        val numChanges = diffList.size
+
+                        (file1, file2, deleted, inserted, numChanges)
+                    }.filter(_._5 > 0)
+                }
+            }
+
+            // TODO update the shuffling
+            // scala.util.Random.setSeed(42)
+            // scala.util.Random.shuffle(incrementalSources).take(/*4*/2).foreach { case (file1, file2, deleted, inserted, numChanges) =>
+            scala.util.Random.shuffle(incrementalSources).take(42).foreach { case (file1, file2, deleted, inserted, numChanges) =>
+                val input1 = read! file1
+                val input2 = read! file2
+                val filename = file2 relativeTo language.sourcesDir
+                // println(filename)
+
+                val results: (Seq[Long], Seq[Long]) = (1 to (warmupIterations + benchmarkIterations)).map { i =>
+                    // println(i)
+                    gc()
+
+                    jsglr2parser.jsglr2.parseResult(input1, "some random name to trigger caching", null)
+
+                    val parserSizeBefore = GraphLayout.parseInstance(jsglr2parser.jsglr2).totalSize()
+                    allocationSizeMeasurer.startMeasure()
+
+                    jsglr2parser.jsglr2.parseResult(input2, "some random name to trigger caching", null)
+
+                    val memoryIncl = allocationSizeMeasurer.endMeasure()
+                    val parserSizeAfter = GraphLayout.parseInstance(jsglr2parser.jsglr2).totalSize()
+
+                    // println("Garbage: " + memoryIncl)
+                    // println("Before:  " + parserSizeBefore)
+                    // println("After:   " + parserSizeAfter)
+                    // println("Cache:   " + (parserSizeAfter - parserSizeBefore))
+
+                    jsglr2parser.jsglr2 match {
+                        case j: org.spoofax.jsglr2.JSGLR2ImplementationWithCache[_, _, _, _, _, _] => j.clearCache()
+                        case _ => ()
+                    }
+
+                    Some((memoryIncl, parserSizeAfter - parserSizeBefore))
+                }.drop(warmupIterations).flatten.unzip
+
+                write.append(resultCsvIncremental, s""""${parser.id}","${filename}",${file1.size},${file2.size},${deleted},${inserted},${numChanges},""")
+                if (results._1.length == 0) {
+                    write.append(resultCsvIncremental, ",,,\n")
+                } else {
+                    val memoryIncl = results._1.sum / results._1.length
+                    val memoryExcl = results._2.sum / results._2.length
+                    val memoryInclError = results._1.map(v => (v - memoryIncl).abs).max
+                    val memoryExclError = results._2.map(v => (v - memoryExcl).abs).max
+
+                    write.append(resultCsvIncremental, s"""${memoryIncl},${memoryInclError},${memoryExcl},${memoryExclError}""" + "\n")
+                }
+            }
+        }
+    }
+}

--- a/scripts/postProcess.sc
+++ b/scripts/postProcess.sc
@@ -117,6 +117,10 @@ suite.languages.foreach { language =>
                         language.antlrBenchmarks.foreach { antlrBenchmark =>
                             processBenchmarkCSV(CSV.parse(benchmarksDir / s"${antlrBenchmark.id}.csv"), _ => antlrBenchmark.id, resultsDir / "time.csv", resultsDir / "throughput.csv", normalize)
                         }
+
+                        if (language.extension == "java") {
+                            processBenchmarkCSV(CSV.parse(benchmarksDir / "tree-sitter.csv"), _ => "tree-sitter", resultsDir / "time.csv", resultsDir / "throughput.csv", normalize)
+                        }
                     }
                 }
             }
@@ -153,25 +157,42 @@ suite.languages.foreach { language =>
             parserTypes.foreach { parserType =>
                 write.append(resultPath, s""","$parserType","$parserType Error (99.9%)"""")
             }
+            parserTypes.filter(_ != "Batch").foreach { parserType =>
+                write.append(resultPath, s""","TreeSitter$parserType","TreeSitter$parserType Error (99.9%)"""")
+            }
             write.append(resultPath, ""","Size (bytes)","Removed","Added","Changes"""" + "\n")
 
             val sourceDir = language.sourcesDir / "incremental" / source.id
             for (i <- 0 until (ls! sourceDir).length) {
-                val csv = try {
+                val csvJSGLR2 = try {
                     CSV.parse(language.benchmarksDir / "jsglr2incremental" / source.id / s"$i.csv")
                 } catch {
                     case _ => CSV(Seq.empty, Seq.empty)
                 }
-                val rows = csv.rows.filter(_("Param: implode") == implode.toString)
+                val csvTreeSitter = try {
+                    CSV.parse(language.benchmarksDir / "tree-sitter-incremental" / source.id / s"$i.csv")
+                } catch {
+                    case _ => CSV(Seq.empty, Seq.empty)
+                }
+
+                val rowsJSGLR2 = csvJSGLR2.rows.filter(_("Param: implode") == implode.toString)
+                val rowsTreeSitter = if (implode) csvTreeSitter.rows else Nil
 
                 write.append(resultPath, i.toString)
 
-                parserTypes.foreach { parserType => {
-                    write.append(resultPath, rows.find(_("Param: parserType") == parserType) match {
+                parserTypes.foreach { parserType =>
+                    write.append(resultPath, rowsJSGLR2.find(_("Param: parserType") == parserType) match {
                         case Some(row) => "," + row("Score") + "," + row("Score Error (99.9%)").replace("NaN", "")
                         case None => ",,"
                     })
-                }}
+                }
+
+                parserTypes.filter(_ != "Batch").foreach { parserType =>
+                    write.append(resultPath, rowsTreeSitter.find(_("Param: parserType") == parserType) match {
+                        case Some(row) => "," + row("Score") + "," + row("Score Error (99.9%)").replace("NaN", "")
+                        case None => ",,"
+                    })
+                }
 
                 val totalSize = ((ls! sourceDir / s"$i") | stat | (_.size)).sum
                 write.append(resultPath, "," + totalSize)

--- a/scripts/postProcess.sc
+++ b/scripts/postProcess.sc
@@ -5,8 +5,7 @@ import $file.spoofaxDeps
 import $ivy.`org.metaborg:org.spoofax.jsglr2:2.6.0-SNAPSHOT`
 
 import org.spoofax.jsglr2.incremental.EditorUpdate
-import org.spoofax.jsglr2.incremental.diff.IStringDiff
-import org.spoofax.jsglr2.incremental.diff.JGitHistogramDiff
+import org.spoofax.jsglr2.incremental.diff.{IStringDiff,JGitHistogramDiff}
 
 import scala.collection.JavaConverters._
 
@@ -188,7 +187,7 @@ suite.languages.foreach { language =>
                 val deleted = diffs.map(diff => diff.asScala.map(_.deletedLength).sum).sum
                 val inserted = diffs.map(diff => diff.asScala.map(_.insertedLength).sum).sum
                 val numChanges = diffs.map(diff => diff.size).sum
-                write.append(resultPath, "," + deleted + "," + inserted + "," + numChanges + "\n")
+                write.append(resultPath, s",${deleted},${inserted},${numChanges}\n")
             }
         }
     }}

--- a/scripts/preProcess.sc
+++ b/scripts/preProcess.sc
@@ -70,8 +70,8 @@ object PreProcessing {
 
                     verdict match {
                         case Some(folder) =>
-                            mkdir! sourcesDir / folder
-                            mv.over(file, sourcesDir / folder / filename.last)
+                            mkdir! sourcesDir / folder / file.relativeTo(sourcesDir) / up
+                            mv.over(file, sourcesDir / folder / file.relativeTo(sourcesDir))
                         case None =>
                     }
                 }

--- a/scripts/preProcess.sc
+++ b/scripts/preProcess.sc
@@ -70,8 +70,13 @@ object PreProcessing {
 
                     verdict match {
                         case Some(folder) =>
-                            mkdir! sourcesDir / folder / file.relativeTo(sourcesDir) / up
-                            mv.over(file, sourcesDir / folder / file.relativeTo(sourcesDir))
+                            val destinationFile = sourcesDir / folder / file.relativeTo(sourcesDir)
+                            mkdir! destinationFile / up
+                            if (verdict == "ambiguous")
+                                // We still want to benchmark ambiguous files, but also want to be able to inspect them
+                                cp.over(file, destinationFile)
+                            else
+                                mv.over(file, destinationFile)
                         case None =>
                     }
                 }


### PR DESCRIPTION
To be merged together with metaborg/jsglr#93.

To run the TreeSitter benchmarks, the benchmark scripts will run `mvn install` for https://github.com/mpsijm/java-tree-sitter before building the benchmark JAR. Note that I've only tested this on Linux.

Benchmark results with this code are available at https://metaborg.github.io/jsglr2evaluation-site/2020-12-23%2023:59/index.html. Note that only the results for Java are shown, I still have to fix that bug :upside_down_face: 