### PR TITLE
Add `Source.name`, report incremental corpus, and other fixes and improvements

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,13 +5,11 @@ WORKDIR /jsglr2evaluation
 RUN mkdir /jsglr2evaluation/bin
 RUN mkdir /jsglr2evaluation/data
 
-RUN apt-get update
-
 # Run apt-get without interactive dialogue
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     curl git locales make software-properties-common vim wget \
     openjdk-8-jdk python3-venv
 
@@ -40,8 +38,7 @@ ENV COURSIER_CACHE /jsglr2evaluation/data/coursier-cache
 # Install R
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 RUN add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
-RUN apt-get update
-RUN apt-get -y install r-base
+RUN apt-get update && apt-get -y install r-base
 
 # Git config
 RUN git config --global user.name "JSGLR2 Evaluation"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,15 @@ RUN apt-get update
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install dependencies
-RUN apt-get install -y software-properties-common openjdk-8-jdk wget curl git make python3-venv vim
+RUN apt-get install -y \
+    curl git locales make software-properties-common vim wget \
+    openjdk-8-jdk python3-venv
+
+# Set the locale to UTF-8 (http://jaredmarkell.com/docker-and-locales/)
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 # Install Maven 3
 RUN cd bin &&\

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -193,9 +193,10 @@ val incrementalTabs = suite.languages.filter(_.sources.incremental.nonEmpty).map
 val memoryTabs = suite.languages.filter(l => exists! dir / "figures" / "memoryBenchmarks" / l.id).map { language =>
     (s"memory-${language.id}", language.name,
         s"""|<div class="row">
-            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-full-garbage.svg" /></div>
-            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-cache-size.svg" /></div>
-            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-incremental.svg" /></div>
+            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-allocations-batch.svg" /></div>
+            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-cache-size-batch.svg" /></div>
+            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-allocations-incremental.svg" /></div>
+            |  <div class="col-lg-6"><img src="./figures/memoryBenchmarks/${language.id}/report-cache-size-incremental.svg" /></div>
             |</div>""".stripMargin)
 }
 

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -153,8 +153,7 @@ def batchLanguageContent(language: Language) = {
     val parseTableMeasurements = language.measurementsParseTable
     val sourcesTabs = (s"batch-${language.id}-all", "All", batchSourceTabContent(language, None)) +:
         language.sourcesBatchNonEmpty.map { source =>
-            // TODO add field source.name to use in tab title?
-            (s"batch-${language.id}-${source.id}", source.id, batchSourceTabContent(language, Some(source)))
+            (s"batch-${language.id}-${source.id}", source.getName, batchSourceTabContent(language, Some(source)))
         }
 
     s"""|<div class="row">
@@ -181,8 +180,7 @@ def batchContent =
 val incrementalTabs = suite.languages.filter(_.sources.incremental.nonEmpty).map { language =>
     val sourcesTabs = language.sources.incremental.map { source =>
         val plots = Seq("report", "report-except-first", "report-time-vs-bytes", "report-time-vs-changes", "report-time-vs-changes-3D")
-        // TODO add field source.name to use in tab title?
-        (s"incremental-${language.id}-${source.id}", source.id, plots.map { plot =>
+        (s"incremental-${language.id}-${source.id}", source.getName, plots.map { plot =>
             s"""<p><img src="./figures/incremental/${language.id}/${source.id}-parse+implode/$plot.svg" /></p>"""
         }.mkString("\n"))
     }

--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -13,7 +13,15 @@ import java.io.{FileInputStream, InputStream}
 // This allows default arguments in ADTs: https://stackoverflow.com/a/47644276
 implicit val customConfig: Configuration = Configuration.default.withDefaults
 
-case class Config(warmupIterations: Int = 1, benchmarkIterations: Int = 1, batchSamples: Int = 1, shrinkBatchSources: Option[Int] = None, languages: Seq[Language], jsglr2variants: Seq[String] = Seq("standard","elkhound","recovery","incremental","recoveryIncremental"))
+case class Config(
+    warmupIterations: Int = 1,
+    benchmarkIterations: Int = 1,
+    batchSamples: Int = 1,
+    shrinkBatchSources: Option[Int] = None,
+    jsglr2variants: Seq[String] = Seq("standard", "elkhound", "recovery", "incremental"),
+    //jsglr2variants: Seq[String] = Seq("standard", "elkhound", "recovery", "recoveryElkhound", "incremental", "recoveryIncremental"),
+    languages: Seq[Language],
+)
 
 case class Language(id: String, name: String, extension: String, parseTable: ParseTable, sources: Sources, antlrBenchmarks: Seq[ANTLRBenchmark] = Seq.empty) {
     def parseTableStream(implicit suite: Suite) = parseTable match {

--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -114,6 +114,7 @@ case class Sources(batch: Seq[BatchSource] = Seq.empty, incremental: Seq[Increme
 
 sealed trait Source {
     def id: String
+    def getName: String
 }
 sealed trait RepoSource extends Source {
     def repo: String
@@ -123,8 +124,12 @@ sealed trait LocalSource extends Source {
 }
 
 sealed trait BatchSource extends Source
-case class BatchRepoSource(id: String, repo: String) extends BatchSource with RepoSource
-case class BatchLocalSource(id: String, path: String) extends BatchSource with LocalSource
+case class BatchRepoSource(id: String, repo: String, name: String = "") extends BatchSource with RepoSource {
+    def getName = if (name == "") id else name
+}
+case class BatchLocalSource(id: String, path: String, name: String = "") extends BatchSource with LocalSource {
+    def getName = if (name == "") id else name
+}
 
 object BatchSource {
     implicit val decodeBatchSource: Decoder[BatchSource] =
@@ -132,8 +137,10 @@ object BatchSource {
         Decoder[BatchLocalSource].map[BatchSource](identity)
 }
 
-case class IncrementalSource(id: String, repo: String,
-        fetchOptions: Seq[String] = Seq.empty, files: Seq[String] = Seq.empty, versions: Int = -1) extends RepoSource
+case class IncrementalSource(id: String, repo: String, name: String = "",
+        fetchOptions: Seq[String] = Seq.empty, files: Seq[String] = Seq.empty, versions: Int = -1) extends RepoSource {
+    def getName = if (name == "") id else name
+}
 
 case class ANTLRBenchmark(id: String, benchmark: String)
 

--- a/scripts/latexTables.sc
+++ b/scripts/latexTables.sc
@@ -32,7 +32,7 @@ def latexTableTestSets(implicit suite: Suite) = {
             val lines = files | read.lines | (_.size) sum
             val size = files | stat | (_.size) sum
 
-            s"  & ${source.id} & ${files.size} & $lines & $size \\\\"
+            s"  & ${source.getName} & ${files.size} & $lines & $size \\\\"
         }
 
         s"""|\\multirow{${language.sourcesBatchNonEmpty.size}}{*}{${language.name}}
@@ -60,7 +60,7 @@ def latexTableTestSetsIncremental(implicit suite: Suite) = {
             val values = Iterator(files, lines, size, (size zip files) map { case (s, f) => s / f })
                 .map(v => thousandSeparator(mean(v).toString))
 
-            s"  & ${source.id} & ${versions.size} & ${values.mkString(" & ")} \\\\"
+            s"  & ${source.getName} & ${versions.size} & ${values.mkString(" & ")} \\\\"
         }
 
         s"""|\\multirow{${sources.size}}{*}{${language.name}}

--- a/scripts/latexTables.sc
+++ b/scripts/latexTables.sc
@@ -15,34 +15,64 @@ case object Throughput extends BenchmarkType {
     def errorColumns = Seq("low" -> "Low", "high" -> "High")
 }
 
+def mean[B](xs: TraversableOnce[B])(implicit num: Integral[B]): Long = num.toLong(xs.sum) / xs.size
+
+def thousandSeparator[T](num: Any) = {
+    val str = num.toString
+    val front = str.length() % 3
+    val (head, toGroup) = str.splitAt(front)
+    val tail = toGroup.grouped(3)
+    (if (front == 0) tail else Iterator(head) ++ tail).mkString("\\,")
+}
+
 def latexTableTestSets(implicit suite: Suite) = {
-    val s = new StringBuilder()
-
-    s.append("\\begin{tabular}{|l|l|r|r|r|}\n")
-    s.append("\\hline\n")
-    s.append("Language & Source & Files & Lines & Size (bytes) \\\\\n")
-    s.append("\\hline\n")
-
-    suite.languages.foreach { language =>
-        s.append("\\multirow{" + language.sourcesBatchNonEmpty.size + "}{*}{" + language.name + "}\n")
-
-        language.sourcesBatchNonEmpty.zipWithIndex.foreach { case (source, index) =>
+    val languages = suite.languages.map { language =>
+        val sources = language.sourcesBatchNonEmpty.map { source =>
             val files = language.sourceFilesBatch(Some(source))
             val lines = files | read.lines | (_.size) sum
             val size = files | stat | (_.size) sum
 
-            s.append("  & " + source.id + " & " + files.size + " & " + lines + " & " + size + " \\\\ ")
-
-            if (index == language.sourcesBatchNonEmpty.size - 1)
-                s.append("\\hline\n");
-            else
-                s.append("\\cline{2-5}\n")
+            s"  & ${source.id} & ${files.size} & $lines & $size \\\\"
         }
+
+        s"""|\\multirow{${language.sourcesBatchNonEmpty.size}}{*}{${language.name}}
+            |${sources.mkString(" \\cline{2-5}\n")}""".stripMargin
     }
 
-    s.append("\\end{tabular}\n")
+    s"""|\\begin{tabular}{|l|l|r|r|r|}
+        |\\hline
+        |Language & Source & Files & Lines & Size (bytes) \\\\ \\hline
+        |${languages.mkString(" \\hline\n")} \\hline
+        |\\end{tabular}
+        |""".stripMargin
+}
 
-    s.toString
+def latexTableTestSetsIncremental(implicit suite: Suite) = {
+    val languages = suite.languages.map { language =>
+        val sources = language.sources.incremental.map { source =>
+            val sourceDir = language.sourcesDir / "incremental" / source.id
+            val versions = (ls! sourceDir)
+            val (files, lines, size) = versions.map(path => (path relativeTo sourceDir).toString.toInt).sorted.map { version =>
+                val versionDir = sourceDir / version.toString
+                val files = (ls! versionDir)
+                (files.size.toLong, (files | read.lines | (_.size) sum).toLong, files | stat | (_.size) sum)
+            }.unzip3
+            val values = Iterator(files, lines, size, (size zip files) map { case (s, f) => s / f })
+                .map(v => thousandSeparator(mean(v).toString))
+
+            s"  & ${source.id} & ${versions.size} & ${values.mkString(" & ")} \\\\"
+        }
+
+        s"""|\\multirow{${sources.size}}{*}{${language.name}}
+            |${sources.mkString(" \\cline{2-7}\n")}""".stripMargin
+    }
+
+    s"""|\\begin{tabular}{|l|l|r|r|r|r|r|}
+        |\\hline
+        |Language & Source & Versions & Files & Lines & Size (B) & Mean file size (B) \\\\ \\hline
+        |${languages.mkString(" \\hline\n")} \\hline
+        |\\end{tabular}
+        |""".stripMargin
 }
 
 def latexTableParseForest(implicit suite: Suite) = {
@@ -163,6 +193,7 @@ def latexTableBenchmarks(benchmarksCSV: CSV, benchmarkType: BenchmarkType)(impli
 mkdir! suite.figuresDir
 
 write.over(suite.figuresDir / "testsets.tex", latexTableTestSets)
+write.over(suite.figuresDir / "testsets-incremental.tex", latexTableTestSetsIncremental)
 write.over(suite.figuresDir / "parseforest.tex", latexTableParseForest)
 write.over(suite.figuresDir / "determinism.tex", latexTableDeterminism)
 

--- a/scripts/memoryBenchmarks.sc
+++ b/scripts/memoryBenchmarks.sc
@@ -26,8 +26,6 @@ println("Executing memory benchmarks...")
 suite.languages.foreach { language =>
     println(" " + language.name)
 
-    val parsers = Parser.variants(language)
-
     val warmupIterations = suite.warmupIterations
     val benchmarkIterations = suite.benchmarkIterations
 
@@ -61,7 +59,7 @@ suite.languages.foreach { language =>
     val sampledFilesBatch = scala.util.Random.shuffle(language.sourceFilesBatch() ++ language.sourceFilesIncremental).take(numSamples)
     val sampledFilesIncremental = scala.util.Random.shuffle(incrementalSources).take(numSamples)
 
-    parsers.filter(_.isInstanceOf[JSGLR2Parser]).foreach { parser =>
+    Parser.jsglr2variants(language).foreach { parser =>
         timed("memoryBenchmarks " + language.id + " " + parser.id) {
             val jsglr2parser = parser.asInstanceOf[JSGLR2Parser]
 

--- a/scripts/parsers.sc
+++ b/scripts/parsers.sc
@@ -135,20 +135,24 @@ object Parser {
         TokenizerVariant.standard()
     )
 
-    def variants(language: Language)(implicit suite: Suite): Seq[Parser] = Seq(
-        //JSGLR1Parser(language),
-        JSGLR2Parser(language, JSGLR2Variant.Preset.standard, false),
-        JSGLR2Parser(language, JSGLR2Variant.Preset.elkhound, false),
-        JSGLR2Parser(language, JSGLR2Variant.Preset.incremental, true),
-        JSGLR2Parser(language, "recovery", recoveryJSGLR2, false),
-        JSGLR2Parser(language, "recoveryEklhound", recoveryElkhoundJSGLR2, false),
-        //JSGLR2Parser(language, JSGLR2Variant.Preset.recoveryIncremental, true),
-    ) ++ language.antlrBenchmarks.map { benchmark =>
-        benchmark.id match {
-            case "antlr" =>
-                ANTLRParser[ANTLR_Java8Lexer, ANTLR_Java8Parser](benchmark.id, new ANTLR_Java8Lexer(_), new ANTLR_Java8Parser(_), _.compilationUnit)
-            case "antlr-optimized" =>
-                ANTLRParser[ANTLR_JavaLexer, ANTLR_JavaParser](benchmark.id, new ANTLR_JavaLexer(_), new ANTLR_JavaParser(_), _.compilationUnit)
+    def jsglr2variants(language: Language)(implicit suite: Suite): Seq[Parser] = suite.jsglr2variants.map(_ match {
+        case "standard"            => JSGLR2Parser(language, JSGLR2Variant.Preset.standard, false)
+        case "elkhound"            => JSGLR2Parser(language, JSGLR2Variant.Preset.elkhound, false)
+        case "incremental"         => JSGLR2Parser(language, JSGLR2Variant.Preset.incremental, true)
+        case "recovery"            => JSGLR2Parser(language, "recovery", recoveryJSGLR2, false)
+        case "recoveryElkhound"    => JSGLR2Parser(language, "recoveryElkhound", recoveryElkhoundJSGLR2, false)
+        case "recoveryIncremental" => JSGLR2Parser(language, JSGLR2Variant.Preset.recoveryIncremental, true)
+    })
+
+    def variants(language: Language)(implicit suite: Suite): Seq[Parser] =
+        //JSGLR1Parser(language) +:
+        jsglr2variants(language) ++
+        language.antlrBenchmarks.map { benchmark =>
+            benchmark.id match {
+                case "antlr" =>
+                    ANTLRParser[ANTLR_Java8Lexer, ANTLR_Java8Parser](benchmark.id, new ANTLR_Java8Lexer(_), new ANTLR_Java8Parser(_), _.compilationUnit)
+                case "antlr-optimized" =>
+                    ANTLRParser[ANTLR_JavaLexer, ANTLR_JavaParser](benchmark.id, new ANTLR_JavaLexer(_), new ANTLR_JavaParser(_), _.compilationUnit)
+            }
         }
-    }
 }

--- a/scripts/setupSources.sc
+++ b/scripts/setupSources.sc
@@ -22,7 +22,7 @@ suite.languages.foreach { language =>
         %%("git", "config", "core.sparseCheckout", "true")(languageSourceRepoDir)
         write(languageSourceRepoDir / ".git" / "info" / "sparse-checkout", source match {
             // If a list of files is given: only checkout these files
-            case IncrementalSource(_, _, _, files, _) if files.nonEmpty => files.mkString("\n")
+            case IncrementalSource(_, _, _, _, files, _) if files.nonEmpty => files.mkString("\n")
             // Else: filter files based on extension
             case _ => "*." + language.extension
         })
@@ -30,10 +30,10 @@ suite.languages.foreach { language =>
         %%("git", "remote", "add", "origin", source.repo)(languageSourceRepoDir)
 
         source match {
-            case BatchRepoSource(_, repo) =>
+            case BatchRepoSource(_, repo, _) =>
                 // Clone without all history
                 %%("git", "fetch", "origin", "master", "--depth=1")(languageSourceRepoDir)
-            case IncrementalSource(_, repo, fetchOptions, _, _) =>
+            case IncrementalSource(_, repo, _, fetchOptions, _, _) =>
                 // Clone with full history, possibly limited by the fetchOptions
                 %%("git", "fetch", "origin", "master", fetchOptions)(languageSourceRepoDir)
         }


### PR DESCRIPTION
Change log is very diverse this time, but with all cool improvements :smile: Most commits should speak for themselves, but some commits can use a bit more explanation:

Commits ded10e3 sets the locale of the Docker image to UTF-8, as by default the locale is not set and falls back to the default POSIX locale (which uses US-ASCII as charset). Ammonite apparently sets the locale to UTF-8 for itself, so preprocessing files with Unicode characters was no problem. However, the JMH benchmark JAR does not do this, so input files with Unicode characters were garbled during the benchmark step and caused failures. :sweat_smile: 

Following this, commit f9c2817 fixes a Docker caching issue where the `apt-get update` command would not get executed after I edited the `apt-get install` command, because it was cached. A common approach to fix this is, apparently, to write `apt-get update && apt-get install ...` instead. That works :shrug: :joy: 

Everything works now, which is confirmed by the test run that has been published at https://www.spoofax.dev/jsglr2evaluation-site/2021-01-22%2000:55/ :smile: