### PR TITLE
Add processing for incremental parsing measurements

### DIFF
--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -213,7 +213,7 @@ def createMeasurementsTable(ids: Seq[String], rows: Seq[Map[String, Long]], head
         |  <tr>
         |    <th>Count</th>
         |    <th>${withTooltip("Ambiguous", "Parse nodes that have multiple derivations")}</th>
-        |    <th>${withTooltip("Non-det.", "Parse nodes that were created when the parser was parsing non-deterministically (i.e., had multiple active parse stacks)")}</th>
+        |    <th>${withTooltip("Irreusable", "Parse nodes that are marked as irreusable, i.e., they were created when the parser was parsing non-deterministically (i.e., had multiple active parse stacks)")}</th>
         |  </tr>
         |  ${indent(2, measurementsAvgRow)}
         |  ${if (header == "Version") s"""<tr><td colspan="7"><br /></td></tr>""" else ""}
@@ -270,8 +270,8 @@ def createMeasurementsTableSkew(skewIds: Seq[String], skewRows: Seq[Map[String, 
         |    <th>Parse Node</th>
         |    <th>Character Node</th>
         |    <th>Count</th>
+        |    <th>${withTooltip("Irreusable", "Parse nodes that were broken down because they are irreusable, i.e., they were created when the parser was parsing non-deterministically (i.e., had multiple active parse stacks)")}</th>
         |    <th>${withTooltip("No Actions", "Parse nodes that were broken down because no actions were found in the parse table")}</th>
-        |    <th>${withTooltip("Non-det.", "Parse nodes that were broken down because they were created when the parser was parsing non-deterministically (i.e., had multiple active parse stacks)")}</th>
         |    <th>${withTooltip("Temporary", "Parse nodes that were broken down because they were created as temporary nodes while applying the text diff to the previous parse forest")}</th>
         |    <th>${withTooltip("Wrong State", "Parse nodes that were broken down because their saved parse state does not match the current state of the parser")}</th>
         |  </tr>

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -180,55 +180,6 @@ def batchContent =
         |</div>
         |${withNav("<h2>Per Language</h2>", batchTabs)}""".stripMargin
 
-object IncrementalMeasurementsTableUtils {
-    val measurementsCells = Seq("parseNodes", "parseNodesAmbiguous", "parseNodesNonDeterministic", "characterNodes")
-
-    val measurementsCellsSkew = Seq(
-        "createParseNode", "parseNodesReused", "parseNodesRebuilt", "shiftParseNode", "shiftCharacterNode",
-        "breakDowns", "breakDownNoActions", "breakDownNonDeterministic", "breakDownTemporary", "breakDownWrongState"
-    )
-
-    val relativeTo = Map(
-        "parseNodesAmbiguous" -> "parseNodes",
-        "parseNodesNonDeterministic" -> "parseNodes",
-        "parseNodesReused" -> "parseNodesPrev",
-        "parseNodesRebuilt" -> "parseNodesPrev",
-        "breakDowns" -> "parseNodesPrev",
-        "breakDownNoActions" -> "breakDowns",
-        "breakDownNonDeterministic" -> "breakDowns",
-        "breakDownTemporary" -> "breakDowns",
-        "breakDownWrongState" -> "breakDowns",
-    )
-
-    def perc(value: Long, total: Long, percentageOnly: Boolean = false) = {
-        val percentage = f"${value * 100.0 / total}%2.2f%%"
-        if (total == 0)
-            s"$value"
-        else
-            if (percentageOnly) percentage else s"$value\n($percentage)"
-    }
-
-    def cellMapper(row: Map[String, Long], percentageOnly: Boolean = false)(key: String) = {
-        val res =
-            if (relativeTo.contains(key))
-                perc(row(key), row(relativeTo(key)), percentageOnly)
-            else
-                row(key).toString
-        res
-    }
-
-    def cellMapperPercs(avgs: Map[String, Long], avgPercs: Map[String, Double])(key: String) = {
-        val res =
-            if (avgPercs.contains(key))
-                f"${avgPercs(key)}%2.2f%%"
-            else
-                avgs(key).toString
-        res
-    }
-
-    def tdWrapper(mapper: (String) => String) = (key: String) => s"<td>${mapper(key).replace("\n", "<br />")}</td>"
-}
-
 def createMeasurementsTable(ids: Seq[String], rows: Seq[Map[String, Long]], header: String) = {
     import IncrementalMeasurementsTableUtils._
 

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -365,6 +365,11 @@ write.over(
     dir / "index.html",
     withTemplate(id, config,
         s"""|<p><strong>Iterations:</strong> ${suite.warmupIterations}/${suite.benchmarkIterations}</p>
+            |<p>
+            |  <strong>Spoofax version</strong>: ${sys.env.get("SPOOFAX_VERSION").getOrElse("master")}<br />
+            |  <strong>JSGLR version</strong>: ${sys.env.get("JSGLR_DIR").getOrElse("develop/jsglr2")}<br />
+            |  <strong>SDF version</strong>: ${sys.env.get("SDF_VERSION").getOrElse("develop/jsglr2")}
+            |</p>
             |${withNav("", tabs)}""".stripMargin
     )
 )

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -82,7 +82,11 @@ if (!dev) {
     val index = Jsoup.parse(new File(indexFile.toString), "UTF-8")
     val ul = index.select("#runs").first
 
-    val badges = suite.scopes.map(scope => s"""<span class="badge badge-primary badge-pill">$scope</span>""").mkString("\n")
+    val isTestRun = suite.warmupIterations <= 3 || suite.benchmarkIterations <= 3
+    val badges = (
+        suite.scopes.map(scope => s"""<span class="badge badge-primary badge-pill">$scope</span>""")
+        ++ (if (isTestRun) Seq("""<span class="badge badge-warning badge-pill">test-run</span>""") else Seq.empty)
+    ).mkString("\n")
     ul.prepend(
         s"""|<a href="./$id/index.html" class="list-group-item list-group-item-action d-flex justify-content-between align-items-center">
             |  $id

--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -367,3 +367,48 @@ implicit class SumMaps(val maps: Seq[Map[String, Long]]) extends AnyVal {
             }.toMap
         }.map { case k -> v => k -> (v / maps.length) }
 }
+
+object IncrementalMeasurementsTableUtils {
+    val measurementsCells = Seq("parseNodes", "parseNodesAmbiguous", "parseNodesNonDeterministic", "characterNodes")
+
+    val measurementsCellsSkew = Seq(
+        "createParseNode", "parseNodesReused", "parseNodesRebuilt", "shiftParseNode", "shiftCharacterNode",
+        "breakDowns", "breakDownNoActions", "breakDownNonDeterministic", "breakDownTemporary", "breakDownWrongState"
+    )
+
+    val relativeTo = Map(
+        "parseNodesAmbiguous" -> "parseNodes",
+        "parseNodesNonDeterministic" -> "parseNodes",
+        "parseNodesReused" -> "parseNodesPrev",
+        "parseNodesRebuilt" -> "parseNodesPrev",
+        "breakDowns" -> "parseNodesPrev",
+        "breakDownNoActions" -> "breakDowns",
+        "breakDownNonDeterministic" -> "breakDowns",
+        "breakDownTemporary" -> "breakDowns",
+        "breakDownWrongState" -> "breakDowns",
+    )
+
+    def perc(value: Long, total: Long, percentageOnly: Boolean = false) = {
+        val percentage = f"${value * 100.0 / total}%2.2f%%"
+        if (total == 0)
+            s"$value"
+        else
+            if (percentageOnly) percentage else s"$value\n($percentage)"
+    }
+
+    def cellMapper(row: Map[String, Long], percentageOnly: Boolean = false)(key: String) = {
+        if (relativeTo.contains(key))
+            perc(row(key), row(relativeTo(key)), percentageOnly)
+        else
+            row(key).toString
+    }
+
+    def cellMapperPercs(avgs: Map[String, Long], avgPercs: Map[String, Double])(key: String) = {
+        if (avgPercs.contains(key))
+            f"${avgPercs(key)}%2.2f%%"
+        else
+            avgs(key).toString
+    }
+
+    def tdWrapper(mapper: (String) => String) = (key: String) => s"<td>${mapper(key).replace("\n", "<br />")}</td>"
+}

--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -67,7 +67,7 @@ case class Language(id: String, name: String, extension: String, parseTable: Par
                 val measurementsCSV = measurementsDir / "incremental" / source.id / "parsing-incremental.csv"
                 val csvRows = CSV.parse(measurementsCSV).rows.map { row =>
                     row.values.map{ case k -> v => k -> v.toLong }
-                }
+                }.filter(_.values.size > 1) // Dropping empty rows
                 val csvRowsExceptLast = csvRows.dropRight(1)
                 val skewRows = csvRowsExceptLast.zip(csvRows.drop(1)).map { case (prevRow, row) =>
                     (prevRow - "version").map{ case k -> v => s"${k}Prev" -> v} ++ row

--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -394,12 +394,12 @@ object IncrementalMeasurementsTableUtils {
 
     val measurementsCellsSkew = Seq(
         "createParseNode", "parseNodesReused", "parseNodesRebuilt", "shiftParseNode", "shiftCharacterNode",
-        "breakDowns", "breakDownNonDeterministic", "breakDownNoActions", "breakDownTemporary", "breakDownWrongState"
+        "breakDowns", "breakDownIrreusable", "breakDownNoActions", "breakDownTemporary", "breakDownWrongState"
     )
 
     val measurementsCellsSummary = Seq(
         "parseNodesNonDeterministic", "parseNodesReused", "breakDowns", "parseNodesRebuilt",
-        "breakDownNonDeterministic", "breakDownNoActions", "breakDownTemporary", "breakDownWrongState"
+        "breakDownIrreusable", "breakDownNoActions", "breakDownTemporary", "breakDownWrongState"
     )
 
     val relativeTo = Map(
@@ -408,8 +408,8 @@ object IncrementalMeasurementsTableUtils {
         "parseNodesReused" -> "parseNodesPrev",
         "parseNodesRebuilt" -> "parseNodesPrev",
         "breakDowns" -> "parseNodesPrev",
+        "breakDownIrreusable" -> "breakDowns",
         "breakDownNoActions" -> "breakDowns",
-        "breakDownNonDeterministic" -> "breakDowns",
         "breakDownTemporary" -> "breakDowns",
         "breakDownWrongState" -> "breakDowns",
     )

--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -373,7 +373,7 @@ object IncrementalMeasurementsTableUtils {
 
     val measurementsCellsSkew = Seq(
         "createParseNode", "parseNodesReused", "parseNodesRebuilt", "shiftParseNode", "shiftCharacterNode",
-        "breakDowns", "breakDownNoActions", "breakDownNonDeterministic", "breakDownTemporary", "breakDownWrongState"
+        "breakDowns", "breakDownNonDeterministic", "breakDownNoActions", "breakDownTemporary", "breakDownWrongState"
     )
 
     val relativeTo = Map(

--- a/scripts/latexTables.sc
+++ b/scripts/latexTables.sc
@@ -64,13 +64,12 @@ def latexTableTestSetsIncremental(implicit suite: Suite) = {
         }
 
         s"""|\\multirow{${sources.size}}{*}{${language.name}}
-            |${sources.mkString(" \\cline{2-7}\n")}""".stripMargin
+            |${sources.mkString("\n")}""".stripMargin
     }
 
-    s"""|\\begin{tabular}{|l|l|r|r|r|r|r|}
-        |\\hline
+    s"""|\\begin{tabular}{l|l|r|r|r|r|r}
         |Language & Source & Versions & Files & Lines & Size (B) & Mean file size (B) \\\\ \\hline
-        |${languages.mkString(" \\hline\n")} \\hline
+        |${languages.mkString(" \\hline\n")}
         |\\end{tabular}
         |""".stripMargin
 }

--- a/scripts/latexTables.sc
+++ b/scripts/latexTables.sc
@@ -156,7 +156,7 @@ def createMeasurementsTableSummary(ids: Seq[String], rows: Seq[Map[String, Long]
 
     val measurementsCells = Seq(
         "parseNodesNonDeterministic", "parseNodesReused", "breakDowns", "parseNodesRebuilt",
-        "breakDownNoActions", "breakDownNonDeterministic", "breakDownTemporary", "breakDownWrongState"
+        "breakDownNonDeterministic", "breakDownNoActions", "breakDownTemporary", "breakDownWrongState"
     )
 
     val measurementsAvgRow =
@@ -166,10 +166,11 @@ def createMeasurementsTableSummary(ids: Seq[String], rows: Seq[Map[String, Long]
         s"$label & ${measurementsCells.map(texWrapper(cellMapper(row, true))).mkString(" & ")}"
     }
 
+    // The resizebox is because the table is 1.05pt too wide otherwise. Hardly noticable, but I want to fix all warnings
     s"""|\\begin{tabular}[t]{c *{${measurementsCells.size}}{|r}}
-        |  \\multirowcell{3}{Language} & \\multicolumn{4}{c|}{Parse nodes (\\% of total nodes)} & \\multicolumn{4}{c}{Breakdowns (\\% of total breakdowns)} \\\\
-        |       & \\multirowcell{2}{Non-\\\\det.} & \\multirowcell{2}{Reused} & \\multirowcell{2}{Broken\\\\down} & \\multirowcell{2}{Rebuilt}
-        |       & \\multirowcell{2}{No\\\\actions} & \\multirowcell{2}{Non-\\\\det.} & \\multirowcell{2}{Tempo-\\\\rary} & \\multirowcell{2}{Wrong\\\\state} \\\\
+        |  \\multirowcell{3}{Language} & \\multicolumn{4}{c|}{Parse nodes (\\% of total nodes)} & \\multicolumn{4}{c}{\\resizebox{0.4\\textwidth}{!}{Breakdowns (\\% of total breakdowns)}} \\\\
+        |       & \\multirowcell{2}{Irre-\\\\usable} & \\multirowcell{2}{Reused} & \\multirowcell{2}{Broken\\\\down} & \\multirowcell{2}{Rebuilt}
+        |       & \\multirowcell{2}{Irre-\\\\usable} & \\multirowcell{2}{No\\\\actions} & \\multirowcell{2}{Tempo-\\\\rary} & \\multirowcell{2}{Wrong\\\\state} \\\\
         |  & & & & & & & & \\\\ \\hline
         |  ${measurementsAvgRow} \\\\ \\hline
         |  ${measurementsRows.mkString(" \\\\\n  ")}
@@ -196,7 +197,7 @@ def createMeasurementsTable(ids: Seq[String], rows: Seq[Map[String, Long]], head
         |  \\multirowcell{3}{$header} & \\multicolumn{3}{c|}{Parse Nodes}   & \\multirowcell{3}{Character\\\\Nodes\\\\Count} \\\\
         |                             & \\multirowcell{2}{Count}
         |                             & \\multirowcell{2}{Ambi-\\\\guous}
-        |                             & \\multirowcell{2}{Non-\\\\det.}     \\\\
+        |                             & \\multirowcell{2}{Irre-\\\\usable}     \\\\
         |  & & & \\\\ \\hline
         |  ${measurementsAvgRow} \\\\ \\hline
         |  ${if (header == "Version") " & & & & \\\\" else ""}
@@ -226,7 +227,7 @@ def createMeasurementsTableSkew(skewIds: Seq[String], skewRows: Seq[Map[String, 
 
     s"""|\\begin{tabular}[t]{c *{${measurementsCellsSkew.size}}{|r}}
         |  \\multirowcell{3}{$header} & \\multicolumn{3}{c|}{Parse Nodes} &                \\multicolumn{2}{c|}{Shift}                & \\multicolumn{5}{c}{Breakdown} \\\\
-        |                             &  Created  &  Reused  &  Rebuilt   & \\makecell{Parse\\\\Node} & \\makecell{Character\\\\Node} & Count & \\makecell{No\\\\Actions} & \\makecell{Non-\\\\det.} & \\makecell{Tempo-\\\\rary} & \\makecell{Wrong\\\\State} \\\\ \\hline
+        |                             &  Created  &  Reused  &  Rebuilt   & \\makecell{Parse\\\\Node} & \\makecell{Character\\\\Node} & Count & \\makecell{Irre-\\\\usable} & \\makecell{No\\\\Actions} & \\makecell{Tempo-\\\\rary} & \\makecell{Wrong\\\\State} \\\\ \\hline
         |  ${measurementsAvgRow} \\\\ \\hline
         |  ${measurementsRows.mkString(" \\\\\n  ")}
         |\\end{tabular}


### PR DESCRIPTION
Processes the results for incremental parsing measurements introduced in metaborg/jsglr#97 and displays them on the [evaluation website](https://www.spoofax.dev/jsglr2evaluation-site/2021-03-02%2015:51/index.html) and converts them to LaTeX tables.

The two types of tables look very similar, so I tried to extract most of the calculations to `common.sc`, specifically `Language.measurementsIncremental` and `IncrementalMeasurementsTableUtils`.
The code that generates the HTML/LaTeX tables look very similar in structure, but it's difficult to extract any remaining duplicate parts due to the large difference in syntax between HTML and LaTeX.

Besides displaying the incremental parsing measurements, I also made some small changes, which you can find back in the commit log and the diff.