### PR TITLE
maven-settings.xml: use snapshots from `master` instead of `cs4200`

### DIFF
--- a/docker/maven-settings.xml
+++ b/docker/maven-settings.xml
@@ -38,7 +38,7 @@
       <repositories>
         <repository>
           <id>metaborg-snapshot-repo</id>
-          <url>https://artifacts.metaborg.org/content/repositories/cs4200/</url>
+          <url>https://artifacts.metaborg.org/content/repositories/snapshots/</url>
           <releases>
             <enabled>false</enabled>
           </releases>
@@ -50,7 +50,7 @@
       <pluginRepositories>
         <pluginRepository>
           <id>metaborg-snapshot-repo</id>
-          <url>https://artifacts.metaborg.org/content/repositories/cs4200/</url>
+          <url>https://artifacts.metaborg.org/content/repositories/snapshots/</url>
           <releases>
             <enabled>false</enabled>
           </releases>


### PR DESCRIPTION
This would explain the build failures I got when trying to build Statix inside the Docker image... :upside_down_face: