### PR TITLE
ISGLR: The final sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ languages:
           repo: https://github.com/apache/commons-lang.git
 ```
 
-This will run the evaluation suite for the Java language and takes the apacha-commons-lang project as corpus.
+This will run the evaluation suite for the Java language and takes the Apache's commons-lang project as corpus.
 
 You can add new languages to the evaluation by adding an entry under the `languages` list.
 In above example, `parseTable.repo` specifies a Git repository of a Spoofax language of which the parse table will be used.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,7 +58,7 @@ COPY docker/Makefile .
 ENV SPOOFAX_VERSION=master
 ENV JSGLR_VERSION=develop/jsglr2
 ENV JSGLR_REMOTE_NAME?=origin
-ENV JSGLR_REMOTE_URL?=http://github.com/metaborg/jsglr
+ENV JSGLR_REMOTE_URL?=https://github.com/metaborg/jsglr
 
 ENV DATA_DIR=/jsglr2evaluation/data
 ENV SPOOFAX_DIR=/jsglr2evaluation/data/spoofax

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,7 +5,7 @@
 SPOOFAX_VERSION?=master
 SDF_VERSION?=develop/jsglr2
 JSGLR_REMOTE_NAME?=origin
-JSGLR_REMOTE_URL?=http://github.com/metaborg/jsglr
+JSGLR_REMOTE_URL?=https://github.com/metaborg/jsglr
 JSGLR_VERSION?=develop/jsglr2
 EVALUATION_TARGET?=all
 

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -9,7 +9,7 @@ println("Adding to website...")
 def indent(spaces: Int, str: String) = str.replaceAll("\n", s"\n${" " * spaces}")
 
 def withTooltip(text: String, tooltip: String) =
-    s"""<a onclick"javascript:void" data-toggle="tooltip" data-placement="top" title="$tooltip">$text</a>"""
+    s"""<a data-toggle="tooltip" data-placement="top" title="$tooltip">$text</a>"""
 
 def withNav(title: String, tabs: Seq[(String, String, String)]) = {
     val active = tabs.filter(_._3 != "").headOption.map(_._1).getOrElse("")

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -284,9 +284,9 @@ val incrementalContent = if (inScope("incremental")) {
             |    <th>Parse Node</th>
             |    <th>Character Node</th>
             |    <th>Count</th>
+            |    <th>${withTooltip("Contains Change", "Parse nodes that were broken down because they contain a change from the diff")}</th>
             |    <th>${withTooltip("Irre&shy;usable", "Parse nodes that were broken down because they are irreusable, i.e., they were created when the parser was parsing non-deterministically (i.e., had multiple active parse stacks)")}</th>
             |    <th>${withTooltip("No Actions", "Parse nodes that were broken down because no actions were found in the parse table")}</th>
-            |    <th>${withTooltip("Tempo&shy;rary", "Parse nodes that were broken down because they were created as temporary nodes while applying the text diff to the previous parse forest")}</th>
             |    <th>${withTooltip("Wrong State", "Parse nodes that were broken down because their saved parse state does not match the current state of the parser")}</th>
             |  </tr>
             |  ${indent(2, measurementsAvgRow)}

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -183,7 +183,7 @@ def batchTabs = suite.languages.filter(_.sourcesBatchNonEmpty.nonEmpty).map { la
     (s"batch-${language.id}", language.name, batchLanguageContent(language))
 }
 
-def batchContent =
+def batchContent = if (inScope("batch")) {
     s"""|<div class="row">""" +
         (if (suite.implode.fold(true)(_ == false))
             s"""|  <div class="col-sm"><img src="./figures/batch/internal-parse/throughput.png" /></div>"""
@@ -196,6 +196,7 @@ def batchContent =
         else "") +
     s"""|</div>
         |${withNav("<h2>Per Language</h2>", batchTabs)}""".stripMargin
+} else ""
 
 val incrementalContent = if (inScope("incremental")) {
     import IncrementalMeasurementsTableUtils._
@@ -368,11 +369,15 @@ val memoryTabs = suite.languages.filter(l => exists! dir / "figures" / "memoryBe
             |</div>""".stripMargin)
 }
 
+val memoryContent = if (memoryTabs.nonEmpty) {
+    withNav("<h2>Per Language</h2>", memoryTabs)
+} else ""
+
 val tabs = Seq(
-    ("batch", "Batch", if (inScope("batch")) batchContent else ""),
+    ("batch", "Batch", batchContent),
     ("recovery", "Recovery", ""),
-    ("incremental", "Incremental", if (inScope("incremental")) incrementalContent else ""),
-    ("memory", "Memory Benchmarks", if (memoryTabs.nonEmpty) withNav("<h2>Per Language</h2>", memoryTabs) else ""),
+    ("incremental", "Incremental", incrementalContent),
+    ("memory", "Memory Benchmarks", memoryContent),
 )
 
 write.over(

--- a/scripts/addToWebsite.sc
+++ b/scripts/addToWebsite.sc
@@ -202,7 +202,7 @@ val incrementalContent = if (inScope("incremental")) {
 
     def tdWrapper(mapper: (String) => String) = (key: String) => s"<td>${mapper(key).replace("\n", "<br />")}</td>"
 
-    def createMeasurementsTable(
+    def createIncrementalMeasurementsTable(
         header: String, ids: Seq[String],
         rows: Seq[Map[String, Long]], percs: Seq[Map[String, Double]],
         avgsLabel: String, avgs: Map[String, Long], avgPercs: Map[String, Double]
@@ -239,7 +239,7 @@ val incrementalContent = if (inScope("incremental")) {
             |</table>""".stripMargin
     }
 
-    def createMeasurementsTableSkew(
+    def createIncrementalMeasurementsTableSkew(
         header: String, ids: Seq[String],
         rows: Seq[Map[String, Long]], percs: Seq[Map[String, Double]],
         avgsLabel: String, avgs: Map[String, Long], avgPercs: Map[String, Double]
@@ -319,8 +319,8 @@ val incrementalContent = if (inScope("incremental")) {
             val skewAvgsLabel = s"Average (${ids(1)}..${ids.last})"
 
             val measurementsTables = incrementalMeasurementsTables(
-                createMeasurementsTable("Version", ids, rows, percs, avgsLabel, avgs, avgPercs),
-                createMeasurementsTableSkew("Version", skewIds, skewRows, skewPercs, skewAvgsLabel, skewAvgs, skewAvgPercs))
+                createIncrementalMeasurementsTable("Version", ids, rows, percs, avgsLabel, avgs, avgPercs),
+                createIncrementalMeasurementsTableSkew("Version", skewIds, skewRows, skewPercs, skewAvgsLabel, skewAvgs, skewAvgPercs))
 
             val plotFilenames = Seq(
                 "report", "report-except-first",
@@ -339,8 +339,8 @@ val incrementalContent = if (inScope("incremental")) {
         val ids = language.sources.incremental.map(_.getName)
 
         val measurementsTables = incrementalMeasurementsTables(
-            createMeasurementsTable("Source", ids, rows, percs, "Average", avgs, avgPercs),
-            createMeasurementsTableSkew("Source", ids, skewRows, skewPercs, "Average", skewAvgs, skewAvgPercs))
+            createIncrementalMeasurementsTable("Source", ids, rows, percs, "Average", avgs, avgPercs),
+            createIncrementalMeasurementsTableSkew("Source", ids, skewRows, skewPercs, "Average", skewAvgs, skewAvgPercs))
 
         (s"incremental-${language.id}", language.name,
             s"""|${measurementsTables}
@@ -348,11 +348,11 @@ val incrementalContent = if (inScope("incremental")) {
     }
 
     val languageNames = languagesWithIncrementalSources.map(_.name)
-    val (rows, percs, skewRows, skewPercs) = getAllMeasurements(languagesWithIncrementalSources)
+    val (rows, percs, skewRows, skewPercs) = getAllIncrementalMeasurements(languagesWithIncrementalSources)
 
     val measurementsTables = incrementalMeasurementsTables(
-        createMeasurementsTable("Language", languageNames, rows, percs, "Average", rows.avgMaps, percs.avgMaps),
-        createMeasurementsTableSkew("Language", languageNames, skewRows, skewPercs, "Average", skewRows.avgMaps, skewPercs.avgMaps))
+        createIncrementalMeasurementsTable("Language", languageNames, rows, percs, "Average", rows.avgMaps, percs.avgMaps),
+        createIncrementalMeasurementsTableSkew("Language", languageNames, skewRows, skewPercs, "Average", skewRows.avgMaps, skewPercs.avgMaps))
 
     s"""|${measurementsTables}
         |${withNav("<h2>Per Language</h2>", incrementalTabs)}""".stripMargin

--- a/scripts/benchmarks.sc
+++ b/scripts/benchmarks.sc
@@ -24,7 +24,7 @@ suite.languages.foreach { language =>
                 "-f", 1.toString,
                 "-rff", resultsPath.toString,
                 name,
-                "-jvmArgs=\"-DtestSet=" + testSetArgs.mkString(" ") + "\""
+                "-jvmArgs=\"-DtestSet=" + testSetArgs.mkString(" ") + "\" -Xmx8G"
             ) ++ params.toSeq.flatMap {
                 case (param, value) => Seq("-p", s"$param=$value")
             }

--- a/scripts/benchmarks.sc
+++ b/scripts/benchmarks.sc
@@ -71,7 +71,7 @@ suite.languages.foreach { language =>
         )
 
     def benchmarkJSGLRIncremental(name: String, resultsPath: Path, sourcePath: Path, params: Map[String, String] = Map.empty) = {
-        for (i <- -1 until (ls! sourcePath).length) {
+        for (i <- 0 until (ls! sourcePath).length) {
             println(f"    iteration $i%3d: start @ ${java.time.LocalDateTime.now}")
             if (i >= 0 && (ls! sourcePath / f"$i").isEmpty) {
                 println(f"      Skipped (no valid sources)")

--- a/scripts/benchmarks.sc
+++ b/scripts/benchmarks.sc
@@ -130,7 +130,7 @@ suite.languages.foreach { language =>
         mkdir! reportDir
         
         timed(s"benchmark [JSGLR2/batch] (w: $warmupIterations, i: $benchmarkIterations) " + language.id + source.fold("")("/" + _.id)) {
-            benchmarkJSGLR("JSGLR2BenchmarkExternal", reportDir / "jsglr2.csv", sourcesDir, "multiple", Map("implode" -> implode.toString, "variant" -> suite.variants.filter(_ != "jsglr1").mkString(",")))
+            benchmarkJSGLR("JSGLR2BenchmarkExternal", reportDir / "jsglr2.csv", sourcesDir, "multiple", Map("implode" -> implode.toString, "variant" -> suite.jsglr2variants.mkString(",")))
         }
 
         if (suite.variants.contains("jsglr1")) {

--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -400,12 +400,12 @@ object IncrementalMeasurementsTableUtils {
 
     val measurementsCellsSkew = Seq(
         "createParseNode", "parseNodesReused", "parseNodesRebuilt", "shiftParseNode", "shiftCharacterNode",
-        "breakDowns", "breakDownIrreusable", "breakDownNoActions", "breakDownTemporary", "breakDownWrongState"
+        "breakDowns", "breakDownHasChange", "breakDownIrreusable", "breakDownNoActions", "breakDownWrongState"
     )
 
     val measurementsCellsSummary = Seq(
         "parseNodesIrreusable", "parseNodesReused", "breakDowns", "parseNodesRebuilt",
-        "breakDownIrreusable", "breakDownNoActions", "breakDownTemporary", "breakDownWrongState"
+        "breakDownHasChange", "breakDownIrreusable", "breakDownNoActions", "breakDownWrongState"
     )
 
     val relativeTo = Map(
@@ -414,6 +414,7 @@ object IncrementalMeasurementsTableUtils {
         "parseNodesReused" -> "parseNodesPrev",
         "parseNodesRebuilt" -> "parseNodesPrev",
         "breakDowns" -> "parseNodesPrev",
+        "breakDownHasChange" -> "breakDowns",
         "breakDownIrreusable" -> "breakDowns",
         "breakDownNoActions" -> "breakDowns",
         "breakDownTemporary" -> "breakDowns",

--- a/scripts/common.sc
+++ b/scripts/common.sc
@@ -252,6 +252,8 @@ case class Suite(configPath: Path, languages: Seq[Language], variants: Seq[Strin
     def resultsDir          = dir / "results"
     def websiteDir          = dir / "website"
 
+    def jsglr2variants = variants.filter(_ != "jsglr1")
+
     def scopes = Seq(
         if (languages.exists(_.sources.batch.nonEmpty)) Some("batch") else None,
         if (languages.exists(_.sources.incremental.nonEmpty)) Some("incremental") else None

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -228,7 +228,7 @@ def main():
                 csv_basename = ".".join(result_file.name.split(".")[:-1])
                 print(f"  {csv_basename}")
 
-                result_data = read_csv(result_file.path)
+                result_data = [row for row in read_csv(result_file.path) if row["Size (bytes)"] != "0"]
                 result_data[0]["Added"] = None
                 result_data_except_first = result_data[1:]
 

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -13,6 +13,7 @@ FIGURES_DIR = environ["JSGLR2EVALUATION_FIGURES_DIR"]
 COLORS = {
     "Standard": "rs",
     "Elkhound": "pm",
+    "Recovery": "o",
     "Incremental": "g^",
     "IncrementalNoCache": "bv",
     "TreeSitterIncremental": "g2",
@@ -22,6 +23,7 @@ COLORS = {
 LABELS = {
     "jsglr2-standard": "Standard",
     "jsglr2-elkhound": "Elkhound",
+    "jsglr2-recovery": "Recovery",
     "jsglr2-incremental": "IncrementalNoCache"
 }
 

--- a/scripts/incrementalPlots.py
+++ b/scripts/incrementalPlots.py
@@ -1,6 +1,8 @@
 import csv
+import math
 from os import makedirs, path, scandir, remove, environ
 
+import matplotlib
 import matplotlib.pyplot as plt
 import mpl_toolkits.mplot3d.art3d as art3d
 import pdftools
@@ -25,6 +27,8 @@ LABELS = {
 
 MiB = 1024 * 1024
 
+matplotlib.rcParams.update({'font.size': 14})
+
 
 def convert_label(label, incremental=False):
     """
@@ -48,13 +52,13 @@ def read_csv(p):
         return [{h: v for h, v in zip(header, line)} for line in lines[1:]]
 
 
-def base_plot(plot_size, title, x_label, y_label, z_label="", subplot_kwargs=None):
+def base_plot(plot_size, title, x_label, y_label, z_label="", subplot_kwargs=None, legend_height=1):
     fig = plt.figure(figsize=plot_size[:2])
     ax = fig.add_subplot(**(subplot_kwargs if subplot_kwargs is not None else {}))
 
     ax.margins(*(0.1 / x for x in plot_size))
 
-    ax.set_title(title, y=1.0 + 0.6 / float(plot_size[1]), va="bottom")
+    ax.set_title(title, y=0.91 + 0.09 * legend_height + 0.6 / float(plot_size[1]), va="bottom")
     ax.set_xlabel(x_label)
     ax.set_ylabel(y_label)
     if z_label:
@@ -125,7 +129,8 @@ def plot_memory_incremental(rows, garbage):
 def plot_times(rows, parser_types):
     n = len(rows)
     plot_size = (8 if n < 50 else 12 if n < 100 else 18 if n < 200 else 24, 6)
-    fig, ax1 = base_plot(plot_size, "Parse time and change size per version", "Version number", "Parse time (ms)")
+    fig, ax1 = base_plot(plot_size, "Parse time and change size per version", "Version number", "Parse time (ms)",
+                         legend_height=math.ceil((len(parser_types) + 1) / 3))
 
     # Plot lines on ax2 below those on ax1 (https://stackoverflow.com/a/57307539)
     ax1.set_zorder(1)  # default z order is 0 for ax1 and ax2
@@ -151,7 +156,7 @@ def plot_times(rows, parser_types):
     # Combine legends for both axes (https://stackoverflow.com/a/10129461)
     lines1, labels1 = ax1.get_legend_handles_labels()
     lines2, labels2 = ax2.get_legend_handles_labels()
-    ax2.legend(lines1 + lines2, labels1 + labels2, loc="lower center", bbox_to_anchor=(0.5, 1.0), ncol=4)
+    ax2.legend(lines1 + lines2, labels1 + labels2, loc="lower center", bbox_to_anchor=(0.5, 1.0), ncol=3)
 
     max_i = max(float(row["i"]) for row in rows)
     ax1.set_xlim(-max_i / 50, max_i + max_i / 50)
@@ -163,7 +168,7 @@ def plot_times(rows, parser_types):
 
 
 def plot_times_vs_changes(rows, unit, *changes):
-    fig, ax = base_plot((8, 6), "Parse time vs. change size", f"Change size ({unit})", "Parse time (ms)")
+    fig, ax = base_plot((8, 6), "Parse time vs. change size", f"Change size ({unit})", "Parse time (ms)", legend_height=0)
 
     x, y = zip(*((sum(int(row[change]) for change in changes), float(row["Incremental"]))
                  for row in rows if row["Incremental"]))
@@ -177,8 +182,8 @@ def plot_times_vs_changes(rows, unit, *changes):
 
 
 def plot_times_vs_changes_3d(rows):
-    fig, ax = base_plot((6, 6, 6), "Parse time vs. change size", "Change size (bytes)", "Change size (chunks)", "Parse time (ms)",
-                        {"projection": "3d"})
+    fig, ax = base_plot((8, 8, 8), "Parse time vs. change size", "Change size (bytes)", "Change size (chunks)", "Parse time (ms)",
+                        {"projection": "3d"}, legend_height=1)
 
     x, y, z = zip(*((int(row["Added"]) + int(row["Removed"]), int(row["Changes"]), float(row["Incremental"]))
                     for row in rows if row["Incremental"]))
@@ -253,7 +258,7 @@ def main():
                 pdftools.pdf_merge([path.join(figure_path, name + ".pdf") for _, name in figures], merged_path)
 
     memory_benchmarks_dir = path.join(DATA_DIR, "memoryBenchmarks")
-    
+
     if path.isdir(memory_benchmarks_dir):
         print("Creating plots for memory benchmarks...")
         for language in scandir(memory_benchmarks_dir):

--- a/scripts/latexTables.sc
+++ b/scripts/latexTables.sc
@@ -463,7 +463,7 @@ if (inScope("incremental")) {
             |    \\legend{Incremental parsing measurements for all languages.}
             |    \\label{tbl:incremental-measurements-all}
             |    \\maxsizebox*{\\linewidth}{\\textheight-2.2em}{%
-            |        \\input{\\generated/figures/incremental/measurements-parsing-incremental}\\hspace{0.5em}%
+            |        \\input{\\generated/figures/incremental/measurements-parsing-incremental}\\hspace{1em}%
             |        \\input{\\generated/figures/incremental/measurements-parsing-incremental-skew}%
             |    }
             |\\end{table}
@@ -477,7 +477,7 @@ if (inScope("incremental")) {
                     |    \\legend{Incremental parsing measurements for the ${language.name} language.}
                     |    \\label{tbl:incremental-measurements-${language.id}}
                     |    \\maxsizebox*{\\linewidth}{\\textheight-2.2em}{%
-                    |        \\input{\\generated/figures/incremental/${language.id}/measurements-parsing-incremental}\\hspace{0.5em}%
+                    |        \\input{\\generated/figures/incremental/${language.id}/measurements-parsing-incremental}\\hspace{1em}%
                     |        \\input{\\generated/figures/incremental/${language.id}/measurements-parsing-incremental-skew}%
                     |    }
                     |\\end{table}
@@ -488,7 +488,7 @@ if (inScope("incremental")) {
                             |    \\legend{Incremental parsing measurements for ${language.name} source ${source.getName}.}
                             |    \\label{tbl:incremental-measurements-${language.id}-${source.id}}
                             |    \\maxsizebox*{\\linewidth}{\\textheight-2.2em}{%
-                            |        \\input{\\generated/figures/incremental/${language.id}/${source.id}-parse/measurements-parsing-incremental}\\hspace{0.5em}%
+                            |        \\input{\\generated/figures/incremental/${language.id}/${source.id}-parse/measurements-parsing-incremental}\\hspace{1em}%
                             |        \\input{\\generated/figures/incremental/${language.id}/${source.id}-parse/measurements-parsing-incremental-skew}%
                             |    }
                             |\\end{table}""".stripMargin

--- a/scripts/latexTables.sc
+++ b/scripts/latexTables.sc
@@ -161,11 +161,11 @@ def createMeasurementsTableSummary(ids: Seq[String], rows: Seq[Map[String, Long]
         s"$label & ${measurementsCellsSummary.map(texWrapper(cellMapper(row, perc, true))).mkString(" & ")}"
     }
 
-    // The resizebox is because the table is 1.05pt too wide otherwise. Hardly noticable, but I want to fix all warnings
+    // The scalebox is because the table is 1.05pt too wide otherwise. Hardly noticable, but I want to fix all warnings
     s"""|\\begin{tabular}[t]{c *{${measurementsCellsSummary.size}}{|r}}
-        |  \\multirowcell{3}{Language} & \\multicolumn{4}{c|}{Parse nodes (\\% of total nodes)} & \\multicolumn{4}{c}{\\resizebox{0.4\\textwidth}{!}{Breakdowns (\\% of total breakdowns)}} \\\\
+        |  \\multirowcell{3}{Language} & \\multicolumn{4}{c|}{Parse nodes (\\% of total nodes)} & \\multicolumn{4}{c}{\\scalebox{0.98}{Breakdowns (\\% of total breakdowns)}} \\\\
         |       & \\multirowcell{2}{Irre-\\\\usable} & \\multirowcell{2}{Reused} & \\multirowcell{2}{Broken\\\\down} & \\multirowcell{2}{Rebuilt}
-        |       & \\multirowcell{2}{Irre-\\\\usable} & \\multirowcell{2}{No\\\\actions} & \\multirowcell{2}{Tempo-\\\\rary} & \\multirowcell{2}{Wrong\\\\state} \\\\
+        |       & \\multirowcell{2}{\\scalebox{0.98}{Contains}\\\\\\scalebox{0.98}{Change}} & \\multirowcell{2}{Irre-\\\\usable} & \\multirowcell{2}{No\\\\actions} & \\multirowcell{2}{Wrong\\\\state} \\\\
         |  & & & & & & & & \\\\ \\hline
         |  ${measurementsAvgRow} \\\\ \\hline
         |  ${measurementsRows.mkString(" \\\\\n  ")}
@@ -221,7 +221,7 @@ def createMeasurementsTableSkew(
 
     s"""|\\begin{tabular}[t]{c *{${measurementsCellsSkew.size}}{|r}}
         |  \\multirowcell{3}{$header} & \\multicolumn{3}{c|}{Parse Nodes} &                \\multicolumn{2}{c|}{Shift}                & \\multicolumn{5}{c}{Breakdown} \\\\
-        |                             &  Created  &  Reused  &  Rebuilt   & \\makecell{Parse\\\\Node} & \\makecell{Character\\\\Node} & Count & \\makecell{Irre-\\\\usable} & \\makecell{No\\\\Actions} & \\makecell{Tempo-\\\\rary} & \\makecell{Wrong\\\\State} \\\\ \\hline
+        |                             &  Created  &  Reused  &  Rebuilt   & \\makecell{Parse\\\\Node} & \\makecell{Character\\\\Node} & Count & \\makecell{Contains\\\\Change} & \\makecell{Irre-\\\\usable} & \\makecell{No\\\\Actions} & \\makecell{Wrong\\\\State} \\\\ \\hline
         |  ${measurementsAvgRow} \\\\ \\hline
         |  ${measurementsRows.mkString(" \\\\\n  ")}
         |\\end{tabular}

--- a/scripts/memoryBenchmarks.sc
+++ b/scripts/memoryBenchmarks.sc
@@ -56,7 +56,7 @@ suite.languages.foreach { language =>
     }
 
     val numSamples = 100 // TODO this could be configurable
-    val sampledFilesBatch = scala.util.Random.shuffle(language.sourceFilesBatch() ++ language.sourceFilesIncremental).take(numSamples)
+    val sampledFilesBatch = scala.util.Random.shuffle(language.sourceFilesBatch() ++ language.sourceFilesIncremental).filter(_.size < 50000).take(numSamples)
     val sampledFilesIncremental = scala.util.Random.shuffle(incrementalSources).take(numSamples)
 
     Parser.jsglr2variants(language).foreach { parser =>

--- a/scripts/parsers.sc
+++ b/scripts/parsers.sc
@@ -135,7 +135,7 @@ object Parser {
         TokenizerVariant.standard()
     )
 
-    def jsglr2variants(language: Language)(implicit suite: Suite): Seq[Parser] = suite.variants.filter(_ != "jsglr1").map(_ match {
+    def jsglr2variants(language: Language)(implicit suite: Suite): Seq[Parser] = suite.jsglr2variants.map(_ match {
         case "standard"            => JSGLR2Parser(language, JSGLR2Variant.Preset.standard, false)
         case "elkhound"            => JSGLR2Parser(language, JSGLR2Variant.Preset.elkhound, false)
         case "incremental"         => JSGLR2Parser(language, JSGLR2Variant.Preset.incremental, true)


### PR DESCRIPTION
To be merged together with metaborg/jsglr#102. 

The long promised cleanup of the benchmark scripts! :smile: 

The commits should be reviewable one-by-one. The first three commits I had already created before my graduation. For most of the commits following that, I already had the uncommitted changes made before my graduation, but I only created commits for them on September 8. The changes to `addToWebsite.sc` that follow, introduce extra statistics to the jsglr2evaluation website that I used in my thesis, for which I had created temporary hacky `println`s to calculate these numbers earlier (as in mpsijm@bdae4362fdebb2f70495e69db083e520edd3adcf).

The added statistics are also visible at https://www.spoofax.dev/jsglr2evaluation-site/2021-06-15_18:13/, the benchmark results that I link to from my thesis. The data is not changed, there are only additions to the presentation of the data, so I guess that's fine. The original web page is still visible at [archive.org (2021-07-07)](https://web.archive.org/web/20210707142208/https://www.spoofax.dev/jsglr2evaluation-site/2021-06-15_18:13/).